### PR TITLE
[v1] Render and output in separate multiprocess

### DIFF
--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -332,12 +332,18 @@ ReplyMessage = Optional[Tuple[BaseException, str]]
 def connection_host(conn: 'Connection'):
     """ Checks for exceptions, then sends a message to the child process. """
     not_first = False
+    # If child process is dead, do not `finally` send None.
+    dead = False
 
     def send(obj) -> None:
-        nonlocal not_first
+        nonlocal not_first, dead
+        if dead:
+            return
+
         if not_first:
             received = conn.recv()  # type: ReplyMessage
             if received:
+                dead = True
                 e, traceback = received
                 print(traceback, file=sys.stderr)
                 raise e

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -301,11 +301,10 @@ class Ovgen:
                             for output in self.outputs:
                                 output.write_frame(frame)
                 except BaseException as e:
-                    tb = traceback.format_exc()
-                    conn.send((e, tb))
+                    conn.send(True)
                     raise
                 else:
-                    conn.send(None)
+                    conn.send(False)
 
     @contextmanager
     def _load_outputs(self):
@@ -325,7 +324,7 @@ class Ovgen:
 
 # message[chan] = trigger_sample (created by trigger)
 Message = List['np.ndarray']
-ReplyMessage = Optional[Tuple[BaseException, str]]
+ReplyMessage = bool  # Has exception occurred?
 
 
 # Parent
@@ -341,12 +340,10 @@ def connection_host(conn: 'Connection'):
             return
 
         if not_first:
-            received = conn.recv()  # type: ReplyMessage
-            if received:
+            is_child_exc = conn.recv()  # type: ReplyMessage
+            if is_child_exc:
                 dead = True
-                e, traceback = received
-                print(traceback, file=sys.stderr)
-                raise e
+                exit(1)
 
         conn.send(obj)
         not_first = True

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -252,7 +252,6 @@ class Ovgen:
         # Terminate render thread.
         finally:
             render_queue.put(None)
-        render_thread.join()
 
         if self.raise_on_teardown:
             raise self.raise_on_teardown
@@ -262,6 +261,9 @@ class Ovgen:
             dtime = time.perf_counter() - begin
             render_fps = (end_frame - begin_frame) / dtime
             print(f'FPS = {render_fps}')
+
+        # Print FPS before waiting for render thread to terminate.
+        render_thread.join()
 
     raise_on_teardown: Exception = None
 


### PR DESCRIPTION
- Increases CPU load
- Utilizes multiple cores
- Trigger load no longer affects framerate
- [x] Remove queue, use Pipe.
    - Worker sends a reply packet to main thread (None for OK, ~~None to signal worker-initiated termination~~, or exception struct to signal worker exceptions)
    - Add pipe-wrapper-class for main thread. All writes (except first) check for reply packet first. Throws if exception occurs.

mutually exclusive:

- [ ] test sending int index, not ndarray
- [ ] don't send `self` (including all wave data) to worker process, it wastes memory
    - https://stackoverflow.com/questions/27318290/why-can-i-pass-an-instance-method-to-multiprocessing-process-but-not-a-multipro

...

- [ ] fix ugly exception cascade on termination. master doesn't suffer from it.
- [ ] fix unit tests