### PR TITLE
Switch appveyor releases to Python 3.7 (possible speed boost)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,8 @@ environment:
     # For Python versions available on Appveyor, see
     # https://www.appveyor.com/docs/windows-images-software/ or
     # https://www.appveyor.com/docs/linux-images-software/
-    - pydir: 'C:\Python37-x64'
-    - pydir: 'C:\Python36'
+    - pydir: 'C:\Python36-x64'
+    - pydir: 'C:\Python37'
   global:
     py: '%pydir%\python.exe'
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
@@ -46,7 +46,7 @@ test_script:
   - 'poetry run pytest --tb=short'
 
 after_test:
-  - 'if not "%pydir%"=="C:\Python36" appveyor exit'
+  - 'if not "%pydir%"=="C:\Python37" appveyor exit'
   # Running pyinstaller is much faster on x64 I think,
   # but the resulting files are 64-bit only.
   - 'poetry build'


### PR DESCRIPTION
why is it so slow and not loading from cache

- 3.7 pyinstaller takes 5 minutes
- 2019-01-03: py3.7 pyinstaller takes 24 minutes :(

closes #102 