### PR TITLE
[wip] Mark GUI as edited when browsing for file, or adding/reordering channels

### DIFF
--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -195,6 +195,7 @@ class MainWindow(qw.QMainWindow):
 
         if self.model is None:
             self.model = ConfigModel(cfg)
+            self.model.edited.connect(self.on_model_edited)
             # Calls self.on_gui_edited() whenever GUI widgets change.
             map_gui(self, self.model)
         else:
@@ -203,12 +204,12 @@ class MainWindow(qw.QMainWindow):
         self.channel_model = ChannelModel(cfg.channels)
         # Calling setModel again disconnects previous model.
         self.channel_view.setModel(self.channel_model)
-        self.channel_model.dataChanged.connect(self.on_gui_edited)
-        self.channel_model.rowsInserted.connect(self.on_gui_edited)
-        self.channel_model.rowsMoved.connect(self.on_gui_edited)
-        self.channel_model.rowsRemoved.connect(self.on_gui_edited)
+        self.channel_model.dataChanged.connect(self.on_model_edited)
+        self.channel_model.rowsInserted.connect(self.on_model_edited)
+        self.channel_model.rowsMoved.connect(self.on_model_edited)
+        self.channel_model.rowsRemoved.connect(self.on_model_edited)
 
-    def on_gui_edited(self):
+    def on_model_edited(self):
         self.any_unsaved = True
 
     title_cache: str
@@ -250,7 +251,6 @@ class MainWindow(qw.QMainWindow):
             master_audio = "master_audio"
             self.model[master_audio] = name
             self.model.update_widget[master_audio]()
-            self.on_gui_edited()
 
     def on_channel_add(self):
         wavs, file_type = qw.QFileDialog.getOpenFileNames(

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -204,6 +204,9 @@ class MainWindow(qw.QMainWindow):
         # Calling setModel again disconnects previous model.
         self.channel_view.setModel(self.channel_model)
         self.channel_model.dataChanged.connect(self.on_gui_edited)
+        self.channel_model.rowsInserted.connect(self.on_gui_edited)
+        self.channel_model.rowsMoved.connect(self.on_gui_edited)
+        self.channel_model.rowsRemoved.connect(self.on_gui_edited)
 
     def on_gui_edited(self):
         self.any_unsaved = True

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -247,6 +247,7 @@ class MainWindow(qw.QMainWindow):
             master_audio = "master_audio"
             self.model[master_audio] = name
             self.model.update_widget[master_audio]()
+            self.on_gui_edited()
 
     def on_channel_add(self):
         wavs, file_type = qw.QFileDialog.getOpenFileNames(

--- a/corrscope/gui/data_bind.py
+++ b/corrscope/gui/data_bind.py
@@ -21,7 +21,7 @@ WidgetUpdater = Callable[[], None]
 Attrs = Any
 
 
-class PresentationModel:
+class PresentationModel(qc.QObject):
     """ Key-value MVP presentation-model.
 
     Qt's built-in model-view framework expects all models to
@@ -33,8 +33,10 @@ class PresentationModel:
     # Although less explicit, these can be assigned using __init_subclass__.
     combo_symbols: Dict[str, List[str]]
     combo_text: Dict[str, List[str]]
+    edited = qc.pyqtSignal()
 
     def __init__(self, cfg: Attrs):
+        super().__init__()
         self.cfg = cfg
         self.update_widget: Dict[str, WidgetUpdater] = {}
 
@@ -46,6 +48,8 @@ class PresentationModel:
             return rgetattr(self.cfg, item)
 
     def __setitem__(self, key, value):
+        self.edited.emit()
+
         # Custom properties
         if hasattr(type(self), key):
             setattr(self, key, value)
@@ -77,7 +81,6 @@ def map_gui(view: "MainWindow", model: PresentationModel):
     for widget in widgets:
         path = widget.objectName()
         widget.bind_widget(model, path)
-        widget.gui_changed.connect(view.on_gui_edited)
 
 
 Signal = Any


### PR DESCRIPTION
- [x] move gui update logic to `PresentationModel.__setitem__`.

performance implications? tomorrow.