### PR TITLE
Fix Renderer leaking matplotlib Figures, add grid tests

### DIFF
--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -179,6 +179,9 @@ class MatplotlibRenderer(Renderer):
                 ax.get_yaxis().set_visible(False)
 
                 # Background color
+                # ax.patch.set_fill(False) sets _fill=False,
+                # then calls _set_facecolor(...) "alpha = self._alpha if self._fill else 0".
+                # It is no faster than below.
                 ax.set_facecolor(self.transparent)
 
                 # Set border colors

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -2,9 +2,9 @@ import os
 from abc import ABC, abstractmethod
 from typing import Optional, List, TYPE_CHECKING
 
+import attr
 import matplotlib
 import numpy as np
-import attr
 
 from corrscope.config import register_config
 from corrscope.layout import RendererLayout, LayoutConfig, EdgeFinder
@@ -32,12 +32,11 @@ if mpl_config_dir in os.environ:
     del os.environ[mpl_config_dir]
 
 matplotlib.use("agg")
-from matplotlib import pyplot as plt
 from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
-    from matplotlib.figure import Figure
     from matplotlib.lines import Line2D
     from corrscope.channel import ChannelConfig
 
@@ -157,7 +156,10 @@ class MatplotlibRenderer(Renderer):
 
         grid_color = self.cfg.grid_color
         axes2d: np.ndarray["Axes"]
-        self._fig, axes2d = plt.subplots(
+        self._fig = Figure()
+        FigureCanvasAgg(self._fig)
+
+        axes2d = self._fig.subplots(
             self.layout.nrows,
             self.layout.ncols,
             squeeze=False,

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,6 +1,7 @@
+import numpy as np
 import pytest
 
-from corrscope.layout import LayoutConfig, RendererLayout
+from corrscope.layout import LayoutConfig, RendererLayout, EdgeFinder
 from corrscope.renderer import RendererConfig, MatplotlibRenderer
 from tests.test_renderer import WIDTH, HEIGHT
 
@@ -72,3 +73,17 @@ def test_renderer_layout():
     # 2 columns, 8 rows
     assert r.layout.ncols == 2
     assert r.layout.nrows == 8
+
+
+# Test EdgeFinder
+
+
+def test_edge_finder():
+    regions2d = np.arange(24).reshape(3, 8)
+    edges = EdgeFinder(regions2d)
+
+    # Check borders
+    np.testing.assert_equal(edges.lefts, regions2d[:, 0])
+    np.testing.assert_equal(edges.rights, regions2d[:, -1])
+    np.testing.assert_equal(edges.tops, regions2d[0, :])
+    np.testing.assert_equal(edges.bottoms, regions2d[-1, :])

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,11 +1,13 @@
+from typing import Optional
+
 import numpy as np
 import pytest
 from matplotlib.colors import to_rgb
 
 from corrscope.channel import ChannelConfig
+from corrscope.layout import LayoutConfig
 from corrscope.outputs import RGB_DEPTH
 from corrscope.renderer import RendererConfig, MatplotlibRenderer
-from corrscope.layout import LayoutConfig
 
 WIDTH = 640
 HEIGHT = 360
@@ -13,62 +15,82 @@ HEIGHT = 360
 ALL_ZEROS = np.array([0, 0])
 
 all_colors = pytest.mark.parametrize(
-    "bg_str,fg_str",
+    "bg_str,fg_str,grid_str",
     [
-        ("#000000", "#ffffff"),
-        ("#ffffff", "#000000"),
-        ("#0000aa", "#aaaa00"),
-        ("#aaaa00", "#0000aa"),
+        ("#000000", "#ffffff", None),
+        ("#ffffff", "#000000", None),
+        ("#0000aa", "#aaaa00", None),
+        ("#aaaa00", "#0000aa", None),
+        # Enabling gridlines enables Axes rectangles.
+        # Make sure they don't draw *over* the global figure background.
+        ("#0000aa", "#aaaa00", "#ff00ff"),  # beautiful magenta gridlines
+        ("#aaaa00", "#0000aa", "#ff00ff"),
     ],
 )
 
+nplots = 2
+
 
 @all_colors
-def test_default_colors(bg_str, fg_str):
+def test_default_colors(bg_str, fg_str, grid_str):
     """ Test the default background/foreground colors. """
-    cfg = RendererConfig(WIDTH, HEIGHT, bg_color=bg_str, init_line_color=fg_str)
+    cfg = RendererConfig(
+        WIDTH, HEIGHT, bg_color=bg_str, init_line_color=fg_str, grid_color=grid_str
+    )
     lcfg = LayoutConfig()
-    nplots = 1
 
     r = MatplotlibRenderer(cfg, lcfg, nplots, None)
-    verify(r, bg_str, fg_str)
+    verify(r, bg_str, fg_str, grid_str)
 
     # Ensure default ChannelConfig(line_color=None) does not override line color
     chan = ChannelConfig(wav_path="")
     channels = [chan] * nplots
     r = MatplotlibRenderer(cfg, lcfg, nplots, channels)
-    verify(r, bg_str, fg_str)
+    verify(r, bg_str, fg_str, grid_str)
 
 
 @all_colors
-def test_line_colors(bg_str, fg_str):
+def test_line_colors(bg_str, fg_str, grid_str):
     """ Test channel-specific line color overrides """
-    cfg = RendererConfig(WIDTH, HEIGHT, bg_color=bg_str, init_line_color="#888888")
+    cfg = RendererConfig(
+        WIDTH, HEIGHT, bg_color=bg_str, init_line_color="#888888", grid_color=grid_str
+    )
     lcfg = LayoutConfig()
-    nplots = 1
 
     chan = ChannelConfig(wav_path="", line_color=fg_str)
     channels = [chan] * nplots
     r = MatplotlibRenderer(cfg, lcfg, nplots, channels)
-    verify(r, bg_str, fg_str)
+    verify(r, bg_str, fg_str, grid_str)
 
 
-def verify(r: MatplotlibRenderer, bg_str, fg_str):
-    r.render_frame([ALL_ZEROS])
+def verify(r: MatplotlibRenderer, bg_str, fg_str, grid_str: Optional[str]):
+    r.render_frame([ALL_ZEROS] * nplots)
     frame_colors: np.ndarray = np.frombuffer(r.get_frame(), dtype=np.uint8).reshape(
         (-1, RGB_DEPTH)
     )
 
     bg_u8 = [round(c * 255) for c in to_rgb(bg_str)]
     fg_u8 = [round(c * 255) for c in to_rgb(fg_str)]
+    all_colors = [bg_u8, fg_u8]
+
+    if grid_str:
+        grid_u8 = [round(c * 255) for c in to_rgb(grid_str)]
+        all_colors.append(grid_u8)
 
     # Ensure background is correct
-    assert (frame_colors[0] == bg_u8).all()
+    bg_frame = frame_colors[0]
+    assert (
+        bg_frame == bg_u8
+    ).all(), f"incorrect background, it might be grid_str={grid_str}"
 
     # Ensure foreground is present
     assert np.prod(
         frame_colors == fg_u8, axis=-1
     ).any(), "incorrect foreground, it might be 136 = #888888"
 
-    assert (np.amax(frame_colors, axis=0) == np.maximum(bg_u8, fg_u8)).all()
-    assert (np.amin(frame_colors, axis=0) == np.minimum(bg_u8, fg_u8)).all()
+    # Ensure grid color is present
+    if grid_str:
+        assert np.prod(frame_colors == grid_u8, axis=-1).any(), "Missing grid_str"
+
+    assert (np.amax(frame_colors, axis=0) == np.amax(all_colors, axis=0)).all()
+    assert (np.amin(frame_colors, axis=0) == np.amin(all_colors, axis=0)).all()


### PR DESCRIPTION
- [x] does coverage work?
- [ ] ~~make it faster by setting Axes grid patch.fill=False~~
- doesn't improve speed.

ax.patch.set_fill(False) sets _fill=False, then calls _set_facecolor(...) "alpha = self._alpha if self._fill else 0".

It is no faster than before.