### PR TITLE
Fix creation of PyInstaller zip files, switch to 7z

### DIFF
--- a/corrscope.spec
+++ b/corrscope.spec
@@ -1,6 +1,7 @@
 import glob
 import os
 import shutil
+import subprocess
 from pathlib import Path
 
 from PyInstaller.building.api import PYZ, EXE, COLLECT
@@ -102,16 +103,22 @@ exe = EXE(
     console=True,
 )
 
+
 class ZipCollect(COLLECT):
-    name: str   # dist/dir-name, != __init__(name=)
+    name: str  # dist/dir-name, != __init__(name=)
 
     def assemble(self):
         ret = super().assemble()
 
-        # No file extension. (make_archive() adds extension)
-        zip_name = str(Path(self.name).with_name(app_name_version))
-        shutil.make_archive(zip_name, 'zip', self.name)
-        assert os.path.getsize(zip_name + '.zip') > 2**20
+        if shutil.which("7z"):
+            cmd_7z = "7z a -mx=3".split()
+
+            # Don't use Path.with_suffix(), it removes trailing semver components.
+            out_name = str(Path(self.name).with_name(app_name_version)) + ".7z"
+            in_files = f"{self.name}/*"  # asterisk removes root directory from archive
+
+            subprocess.run(cmd_7z + [out_name, in_files], check=True)
+            assert os.path.getsize(out_name) > 2 ** 20
 
         return ret
 

--- a/corrscope.spec
+++ b/corrscope.spec
@@ -1,5 +1,6 @@
 import glob
-import zipfile
+import os
+import shutil
 from pathlib import Path
 
 from PyInstaller.building.api import PYZ, EXE, COLLECT
@@ -7,7 +8,6 @@ from PyInstaller.building.build_main import Analysis
 from PyInstaller.building.datastruct import TOC
 
 from corrscope import version as v
-
 
 block_cipher = None
 
@@ -103,14 +103,15 @@ exe = EXE(
 )
 
 class ZipCollect(COLLECT):
-    name: str   # absolute-ish path, != __init__(name=)
+    name: str   # dist/dir-name, != __init__(name=)
 
     def assemble(self):
         ret = super().assemble()
 
-        new_name = str(Path(self.name).with_name(app_name_version))
-        with zipfile.ZipFile(new_name + '.zip', 'w', zipfile.ZIP_DEFLATED) as z:
-            z.write(self.name)
+        # No file extension. (make_archive() adds extension)
+        zip_name = str(Path(self.name).with_name(app_name_version))
+        shutil.make_archive(zip_name, 'zip', self.name)
+        assert os.path.getsize(zip_name + '.zip') > 2**20
 
         return ret
 


### PR DESCRIPTION
#137 caused zip files to become empty.

7z files compress large 64-bit binaries better.