### PR TITLE
[v2] Multiprocess render

### DIFF
--- a/corrscope/parallelism.py
+++ b/corrscope/parallelism.py
@@ -32,7 +32,6 @@ frame 1:
 frame:
 - parent reads and quits
 """
-import datetime
 from abc import ABC, abstractmethod
 from enum import Enum, auto
 from multiprocessing import Process, Pipe
@@ -40,8 +39,6 @@ from multiprocessing.connection import Connection
 from typing import *
 
 import numpy as np
-
-from corrscope.util import perr
 
 __all__ = [
     "Message",
@@ -137,7 +134,6 @@ class ParallelWorker(Worker):
         # Receive reply from child.
         if self._not_first:
             is_aborted_or_error = self._parent_conn.recv()  # type: ReplyOrError
-            perr(datetime.datetime.now(), "parent recv", str(is_aborted_or_error)[:10])
             if is_aborted_or_error is not False:
                 self._child_dead = True
 
@@ -150,7 +146,6 @@ class ParallelWorker(Worker):
                 pass
 
         # Send parent message.
-        perr(datetime.datetime.now(), "parent to child", str(msg)[:10])
         self._parent_conn.send(msg)
         self._not_first = True
 
@@ -165,7 +160,6 @@ class ParallelWorker(Worker):
             while True:
                 # Receive parent message.
                 msg = child_conn.recv()
-                perr(datetime.datetime.now(), "child recv", str(msg)[:10])
                 if msg is None:
                     break  # See module docstring
 
@@ -173,11 +167,9 @@ class ParallelWorker(Worker):
                 try:
                     reply = child_job.foreach(msg)
                 except BaseException as e:
-                    perr(datetime.datetime.now(), "child Error")
                     child_conn.send(Error.Error)
                     raise
                 else:
-                    perr(datetime.datetime.now(), "child to parent", str(reply)[:10])
                     child_conn.send(reply)
                     if reply:
                         break

--- a/corrscope/parallelism.py
+++ b/corrscope/parallelism.py
@@ -1,37 +1,93 @@
-from typing import List, Iterator, TYPE_CHECKING, Callable, Union
+from abc import ABC, abstractmethod
+from multiprocessing import Process, Pipe
+from multiprocessing.connection import Connection
+from typing import List, Iterator, Callable, Union
 
 import numpy as np
 
-if TYPE_CHECKING:
-    from multiprocessing.connection import Connection
+__all__ = [
+    "Message",
+    "ReplyMessage",
+    "Worker",
+    "ParallelWorker",
+    # "SerialWorker",
+    "iter_conn",
+]
 
 
 Message = Union[List[np.ndarray], None]
 ReplyMessage = bool  # Has exception occurred?
 
 
-# Parent
-def connection_host(conn: "Connection") -> Callable[[Message], None]:
-    """ Checks for exceptions, then sends a message to the child process. """
-    not_first = False
-    # If child process is dead, do not `finally` send None.
-    dead = False
+class Worker(ABC):
+    @abstractmethod
+    def __init__(self, child_func: Callable[[Connection], None]):
+        pass
 
-    def send(obj: Message) -> None:
-        nonlocal not_first, dead
-        if dead:
-            return
+    def __enter__(self):
+        pass
 
-        if not_first:
-            is_child_exc = conn.recv()  # type: ReplyMessage
+    @abstractmethod
+    def parent_send(self, obj: Message) -> None:
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+# noinspection PyAttributeOutsideInit
+class ParallelWorker(Worker):
+    _parent_conn: Connection
+
+    def __init__(self, child_func: Callable[[Connection], None], name: str = None):
+        """ To pass parameters to child_func, wrap it in a closure.
+        This allows for type-checking. """
+        super().__init__(child_func)
+
+        _child_conn: Connection
+        self._parent_conn, _child_conn = Pipe(duplex=True)
+
+        self._child_thread = Process(name=name, target=child_func, args=[_child_conn])
+        self._child_thread.start()
+
+    def __enter__(self):
+        """ Ensure this class cannot be called without a with statement. """
+        self._not_first = False
+        self._child_dead = False
+        return self
+
+    def parent_send(self, obj: Message) -> None:
+        """ Checks for exceptions, then sends a message to the child process. """
+
+        # If child process is dead, do not `finally` send None.
+        try:
+            if self._child_dead:
+                return
+        except AttributeError:
+            raise ValueError(
+                "Must use `with` clause (__enter__) before calling parent_send"
+            )
+
+        if self._not_first:
+            is_child_exc = self._parent_conn.recv()  # type: ReplyMessage
             if is_child_exc:
-                dead = True
+                self._child_dead = True
                 exit(1)
 
-        conn.send(obj)
-        not_first = True
+        self._parent_conn.send(obj)
+        self._not_first = True
 
-    return send
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.parent_send(None)
+        self._parent_conn.close()
+        self._child_thread.join()
+
+
+# class SerialWorker(Worker):
+#     pass
+
+
+# Parent
 
 
 # Child

--- a/corrscope/parallelism.py
+++ b/corrscope/parallelism.py
@@ -1,14 +1,49 @@
+"""
+- Parent sends messages to child.
+- Child replies False to every message except final None.
+- If child crashes, it sends True and terminates.
+
+# Normal operation
+
+frame 0:
+- parent to child
+- child reads
+... child to parent
+
+frame 1:
+- parent reads
+- parent to child
+- child reads
+... child to parent
+
+# End of song
+
+- parent reads
+- parent to child "do not reply"
+- child reads, and quits
+
+# Child exception
+
+- parent reads
+- parent to child
+- child reads
+... child to parent "error", and quits
+
+frame:
+- parent reads and quits
+"""
 from abc import ABC, abstractmethod
+from enum import Enum, auto
 from multiprocessing import Process, Pipe
 from multiprocessing.connection import Connection
-from typing import List, Iterator, Optional
+from typing import *
 
 import numpy as np
 
 __all__ = [
     "Message",
     "MaybeMessage",
-    "ReplyMessage",
+    "ReplyIsAborted",
     # "Worker",
     "ParallelWorker",
     # "SerialWorker",
@@ -17,7 +52,14 @@ __all__ = [
 
 Message = List[np.ndarray]
 MaybeMessage = Optional[Message]
-ReplyMessage = bool  # Has exception occurred?
+
+
+class Error(Enum):
+    Error = auto()
+
+
+ReplyIsAborted = bool  # Is aborted?
+ReplyOrError = Union[ReplyIsAborted, Error]
 
 
 class Job(ABC):
@@ -28,7 +70,14 @@ class Job(ABC):
         return self
 
     @abstractmethod
-    def foreach(self, msg: Message) -> ReplyMessage:
+    def foreach(self, msg: Message) -> ReplyIsAborted:
+        """
+        False: not aborted
+        True: aborted without error (ffplay closed).
+        raise: error.
+
+        do *not* return Error.
+        """
         pass
 
     @abstractmethod
@@ -36,46 +85,33 @@ class Job(ABC):
         pass
 
 
-# class Worker(ABC):
-#     @abstractmethod
-#     def __init__(self, child_job: "Job"):
-#         # self.child_job = child_job
-#         pass
-#
-#     def __enter__(self):
-#         pass
-#
-#     @abstractmethod
-#     def parent_send(self, msg: Message) -> None:
-#         pass
-#
-#     def __exit__(self, exc_type, exc_val, exc_tb):
-#         pass
+class Worker(ABC):
+    @abstractmethod
+    def __init__(self, child_job: Job, name: str = None):
+        pass
+
+    def __enter__(self):
+        pass
+
+    @abstractmethod
+    def parent_send(self, msg: MaybeMessage) -> ReplyIsAborted:
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
 
 
 # noinspection PyAttributeOutsideInit
-class ParallelWorker:
+class ParallelWorker(Worker):
     _parent_conn: Connection
 
     def __init__(self, child_job: Job, name: str = None):
+        super().__init__(child_job, name)
         self._parent_conn, child_conn = Pipe(duplex=True)
 
         self._child_thread = Process(
             name=name, target=self._child_thread_func, args=[child_job, child_conn]
         )
-
-    @staticmethod
-    def _child_thread_func(child_job: Job, child_conn: Connection):
-        """ Must be called from thread. """
-        with child_job:
-            for msg in iter_conn(child_conn):
-                try:
-                    reply = child_job.foreach(msg)
-                except BaseException as e:
-                    child_conn.send(True)
-                    raise
-                else:
-                    child_conn.send(reply)
 
     def __enter__(self):
         """ Ensure this class cannot be called without a with statement. """
@@ -85,45 +121,81 @@ class ParallelWorker:
         self._child_dead = False
         return self
 
-    def parent_send(self, msg: Message) -> None:
+    def parent_send(self, msg: MaybeMessage) -> ReplyIsAborted:
         """ Checks for exceptions, then sends a message to the child process. """
-
-        # If child process is dead, do not `finally` send None.
         try:
             if self._child_dead:
-                return
+                raise ValueError("cannot send to dead worker")
         except AttributeError:
             raise ValueError(
                 "Must use `with` clause (__enter__) before calling parent_send"
             )
 
+        # Receive reply from child.
         if self._not_first:
-            is_child_exc = self._parent_conn.recv()  # type: ReplyMessage
-            if is_child_exc:
+            is_aborted_or_error = self._parent_conn.recv()  # type: ReplyOrError
+            if is_aborted_or_error is not False:
                 self._child_dead = True
-                exit(1)
 
+            # https://github.com/python/mypy/issues/1803
+            if isinstance(is_aborted_or_error, Error):
+                exit(1)  # Stack trace is printed by child process.
+            elif is_aborted_or_error:
+                return True
+            else:
+                pass
+
+        # Send parent message.
         self._parent_conn.send(msg)
         self._not_first = True
 
+        return False
+
+    @staticmethod
+    def _child_thread_func(child_job: Job, child_conn: Connection):
+        """ Must be called from thread. """
+        with child_job:
+            msg: Message
+
+            while True:
+                # Receive parent message.
+                msg = child_conn.recv()
+                if msg is None:
+                    break  # See module docstring
+
+                # Reply to parent (and optionally terminate).
+                try:
+                    reply = child_job.foreach(msg)
+                except BaseException as e:
+                    child_conn.send(Error.Error)
+                    raise
+                else:
+                    child_conn.send(reply)
+                    if reply:
+                        break
+
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.parent_send(None)
+        if not self._child_dead:
+            self.parent_send(None)
+
+        self._child_dead = True
         self._parent_conn.close()
         self._child_thread.join()
 
 
-# class SerialWorker(Worker):
-#     pass
+class SerialWorker(Worker):
+    def __init__(self, child_job: Job, name: str = None):
+        super().__init__(child_job, name)
+        self.child_job = child_job
 
+    def __enter__(self):
+        self.child_job.__enter__()
+        return self
 
-# Parent
+    def parent_send(self, msg: MaybeMessage) -> ReplyIsAborted:
+        if msg is None:
+            return False
+        return self.child_job.foreach(msg)
 
-
-# Child
-def iter_conn(conn: "Connection") -> Iterator[Message]:
-    """ Yields elements of a threading queue, stops on None. """
-    while True:
-        item = conn.recv()
-        if item is None:
-            break
-        yield item
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.child_job.__exit__(exc_type, exc_val, exc_tb)

--- a/corrscope/parallelism.py
+++ b/corrscope/parallelism.py
@@ -180,7 +180,10 @@ class ParallelWorker(Worker):
 
         self._child_dead = True
         self._parent_conn.close()
-        self._child_thread.join()
+        self._child_thread.join(1)
+        if self._child_thread.exitcode is None:
+            self._child_thread.terminate()
+            raise ValueError("renderer thread failed to terminate after 1 second")
 
 
 class SerialWorker(Worker):

--- a/corrscope/parallelism.py
+++ b/corrscope/parallelism.py
@@ -1,0 +1,44 @@
+from typing import List, Iterator, TYPE_CHECKING, Callable, Union
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from multiprocessing.connection import Connection
+
+
+Message = Union[List[np.ndarray], None]
+ReplyMessage = bool  # Has exception occurred?
+
+
+# Parent
+def connection_host(conn: "Connection") -> Callable[[Message], None]:
+    """ Checks for exceptions, then sends a message to the child process. """
+    not_first = False
+    # If child process is dead, do not `finally` send None.
+    dead = False
+
+    def send(obj: Message) -> None:
+        nonlocal not_first, dead
+        if dead:
+            return
+
+        if not_first:
+            is_child_exc = conn.recv()  # type: ReplyMessage
+            if is_child_exc:
+                dead = True
+                exit(1)
+
+        conn.send(obj)
+        not_first = True
+
+    return send
+
+
+# Child
+def iter_conn(conn: "Connection") -> Iterator[Message]:
+    """ Yields elements of a threading queue, stops on None. """
+    while True:
+        item = conn.recv()
+        if item is None:
+            break
+        yield item


### PR DESCRIPTION
v1 at https://github.com/jimbo1qaz/corrscope/pull/67

- [ ] forward exceptions to main process, so GUI can show it
- [x] pass int indices, not slow ndarray (IPC queue is pickled)
    - still unbearable overhead on Linux

~~print fps on keyboard interrupt~~ missing from master, `Aborted!`