### PR TITLE
Don't run mypy in Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,6 @@ build_script:
 test_script:
   - 'poetry run pytest --tb=short --cov=corrscope'
   - 'poetry run codecov'
-  - 'poetry run mypy corrscope'
 
 after_test:
   - 'if not "%pydir%"=="C:\Python37-x64" appveyor exit'


### PR DESCRIPTION
I think it's degrading code quality via mypy-specific hacks and
inconsistencies with Pycharm.

It's also slowing down development, but making me reread and cleanup PR
diffs may be a good thing.