### PR TITLE
Per channel amplification (overrides global)

### DIFF
--- a/corrscope/channel.py
+++ b/corrscope/channel.py
@@ -17,14 +17,15 @@ class ChannelConfig(DumpableAttrs):
     wav_path: str
 
     # Supplying a dict inherits attributes from global trigger.
-    trigger: Union[ITriggerConfig, Dict[str, Any], None] = attr.Factory(  # type: ignore
-        dict
-    )  # TODO test channel-specific triggers
+    # TODO test channel-specific triggers
+    trigger: Union[ITriggerConfig, Dict[str, Any], None] = attr.Factory(dict)
+
     # Multiplies how wide the window is, in milliseconds.
     trigger_width: int = 1
     render_width: int = 1
 
-    ampl_ratio: float = 1.0  # TODO use amplification = None instead?
+    # Overrides global amplification.
+    amplification: Optional[float] = None
 
     # Stereo config
     trigger_stereo: Optional[Flatten] = None
@@ -53,7 +54,8 @@ class Channel:
 
         # Create a Wave object.
         wave = Wave(
-            abspath(cfg.wav_path), amplification=corr_cfg.amplification * cfg.ampl_ratio
+            abspath(cfg.wav_path),
+            amplification=coalesce(cfg.amplification, corr_cfg.amplification),
         )
 
         # Flatten wave stereo for trigger and render.

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -799,6 +799,7 @@ class ChannelModel(qc.QAbstractTableModel):
     # columns
     col_data = [
         Column("wav_path", path_strip_quotes, "", "WAV Path"),
+        Column("amplification", float, None, "Amplification\n(override)"),
         Column("trigger_width", int, None, "Trigger Width ×"),
         Column("render_width", int, None, "Render Width ×"),
         Column("line_color", str, None, "Line Color"),

--- a/corrscope/gui/mainwindow.ui
+++ b/corrscope/gui/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1080</width>
+    <width>1160</width>
     <height>0</height>
    </rect>
   </property>


### PR DESCRIPTION
Replace unused per-channel amplification multiplier.

Add test to ensure per-channel amplification overrides global.