### PR TITLE
[renderer] Treat line_width as pixels, not points

### DIFF
--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -274,7 +274,7 @@ class MatplotlibRenderer(Renderer):
             self._save_background()
 
             # Plot lines over background
-            line_width = cfg.line_width
+            line_width = pixels(cfg.line_width)
             self._lines = []
 
             for idx, data in enumerate(datas):

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -35,7 +35,12 @@ nplots = 2
 def test_default_colors(bg_str, fg_str, grid_str):
     """ Test the default background/foreground colors. """
     cfg = RendererConfig(
-        WIDTH, HEIGHT, bg_color=bg_str, init_line_color=fg_str, grid_color=grid_str
+        WIDTH,
+        HEIGHT,
+        bg_color=bg_str,
+        init_line_color=fg_str,
+        grid_color=grid_str,
+        line_width=2.0,
     )
     lcfg = LayoutConfig()
 
@@ -53,7 +58,12 @@ def test_default_colors(bg_str, fg_str, grid_str):
 def test_line_colors(bg_str, fg_str, grid_str):
     """ Test channel-specific line color overrides """
     cfg = RendererConfig(
-        WIDTH, HEIGHT, bg_color=bg_str, init_line_color="#888888", grid_color=grid_str
+        WIDTH,
+        HEIGHT,
+        bg_color=bg_str,
+        init_line_color="#888888",
+        grid_color=grid_str,
+        line_width=2.0,
     )
     lcfg = LayoutConfig()
 


### PR DESCRIPTION
Convert line_width from pixels to points (96dpi)

- Why not switch to 72dpi, where 1pt = 1px?
  - Gridlines become too thin, and change from white to gray.
    This is bad for users, and causes unit tests to fail.

Fixes #178.