### PR TITLE
Fix rgetattr() with default (pointless)

### DIFF
--- a/corrscope/gui/data_bind.py
+++ b/corrscope/gui/data_bind.py
@@ -495,11 +495,13 @@ def rgetattr(obj: DumpableAttrs, dunder_delim_path: str, *default) -> Any:
     :return: obj.attr1.attr2.etc
     """
 
-    def _getattr(obj, attr):
-        return getattr(obj, attr, *default)
-
     attrs: List[Any] = dunder_delim_path.split(DUNDER)
-    return functools.reduce(_getattr, [obj] + attrs)
+    try:
+        return functools.reduce(getattr, attrs, obj)
+    except AttributeError:
+        if default:
+            return default[0]
+        raise
 
 
 def rhasattr(obj, dunder_delim_path: str):

--- a/tests/test_gui_binding.py
+++ b/tests/test_gui_binding.py
@@ -55,9 +55,6 @@ def test_rgetattr():
     assert not rhasattr(p, "ghost__species")
 
 
-@pytest.mark.xfail(
-    reason="rgetattr copied from Stack Overflow and subtly broken", strict=True
-)
 def test_rgetattr_broken():
     """
     rgetattr(default) fails to short-circuit/return on the first missing attribute.
@@ -72,5 +69,5 @@ def test_rgetattr_broken():
     - None.foo AKA return 1 to caller
     """
 
-    result = rgetattr(None, "foo__bar__imag", 1)
+    result = rgetattr(object(), "nothing__imag", 1)
     assert result == 1, result


### PR DESCRIPTION
Pointless because I never call rgetattr(default=value) at all.