### PR TITLE
Always run pytest --tb=native (less bloated stack traces)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [tool:pytest]
 testpaths = tests
 xfail_strict=true
+addopts = --tb=native
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
By default, pytest prints entire docstring of innermost function (which can be very long in libraries).