### PR TITLE
Fix pytest working dir in Pycharm

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,18 @@ Integration tests found in:
 
 import os
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
 if TYPE_CHECKING:
     import pytest_mock
+
+
+# Pycharm sets cwd to /tests/.
+# To ensure tests can find WAV files (based on /), jump from /tests/conftest.py to /.
+os.chdir(Path(__file__).parent.parent)
 
 
 @pytest.fixture


### PR DESCRIPTION
My unit tests assume cwd = /, in order to locate wav files.
But Pycharm uses the wrong working dir whenever you "rerun failed tests" or "run tests in file".
This runs `chdir(correct dir)`.