### PR TITLE
Add antialiasing toggle, disable antialiasing during renderer tests

### DIFF
--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -63,6 +63,8 @@ class RendererConfig(DumpableAttrs, always_dump="*"):
     v_midline: bool = False
     h_midline: bool = False
 
+    antialiasing: bool = True
+
     # Performance (skipped when recording to video)
     res_divisor: float = 1.0
 
@@ -158,6 +160,10 @@ class MatplotlibRenderer(Renderer):
 
     def __init__(self, *args, **kwargs):
         Renderer.__init__(self, *args, **kwargs)
+
+        dict.__setitem__(
+            matplotlib.rcParams, "lines.antialiased", self.cfg.antialiasing
+        )
 
         # Flat array of nrows*ncols elements, ordered by cfg.rows_first.
         self._fig: "Figure"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -41,6 +41,7 @@ def test_default_colors(bg_str, fg_str, grid_str):
         init_line_color=fg_str,
         grid_color=grid_str,
         line_width=2.0,
+        antialiasing=False,
     )
     lcfg = LayoutConfig()
 
@@ -64,6 +65,7 @@ def test_line_colors(bg_str, fg_str, grid_str):
         init_line_color="#888888",
         grid_color=grid_str,
         line_width=2.0,
+        antialiasing=False,
     )
     lcfg = LayoutConfig()
 


### PR DESCRIPTION
I will add renderer tests for semi-transparent blended lines. Disabling AA will prevent antialiasing from acting as a blended color.

- [ ] expose to user? later? 
  - always_dump=* so it will be exposed