### PR TITLE
Add basic test to ensure initializing GUI doesn't crash

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,10 @@
+import PyQt5.QtWidgets as qw
+
+from corrscope import gui
+from corrscope.corrscope import default_config
+
+
+def test_gui_init():
+    app = qw.QApplication([])
+    cfg = default_config()
+    gui.MainWindow(cfg)


### PR DESCRIPTION
Not calling `app.exec_()` ensures that no window pops up and blocks user input.