### PR TITLE
Rewrite area trigger, don't use correlation

### DIFF
--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -224,6 +224,7 @@ class CorrelationTrigger(MainTrigger):
     - So wave.get_around(x) = [x - N//2 : ...]
 
     test_trigger() checks that get_around() works properly, for even/odd N.
+    See Wave.get_around() docstring.
     """
 
     cfg: CorrelationTriggerConfig
@@ -412,6 +413,8 @@ class CorrelationTrigger(MainTrigger):
         """
         Input: length N
         Output: length N
+        - mid = N//2
+        - result[mid=N//2] == self[sample]
         - Note that correlate() is length 2N-1, which is different.
 
         # Implementation details

--- a/corrscope/wave.py
+++ b/corrscope/wave.py
@@ -200,8 +200,9 @@ class Wave:
     def get_around(self, sample: int, return_nsamp: int, stride: int) -> np.ndarray:
         """ Returns `return_nsamp` samples, centered around `sample`,
         sampled with spacing `stride`.
+        result[N//2] == self[sample]. See CorrelationTrigger docstring.
 
-        Copies self.data[...] """
+        Copies self.data[...]. """
         distance = return_nsamp * stride
         begin = sample - distance // 2
         end = begin + distance

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -52,7 +52,10 @@ is_odd = parametrize("is_odd", [False, True])
 def test_trigger(cfg: CorrelationTriggerConfig, is_odd: bool, post_trigger):
     """Ensures that trigger can locate
     the first positive sample of a -+ step exactly,
-    without off-by-1 errors."""
+    without off-by-1 errors.
+
+    See CorrelationTrigger and Wave.get_around() docstrings.
+    """
     wave = Wave("tests/step2400.wav")
     cfg = attr.evolve(cfg, post_trigger=post_trigger)
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -217,7 +217,7 @@ def test_correlate_offset():
     """
 
     np.random.seed(31337)
-    correlate_offset = CorrelationTrigger.correlate_offset
+    correlate_offset = CorrelationTrigger.correlate_buffer
 
     # Ensure autocorrelation on random data returns peak at 0.
     N = 100


### PR DESCRIPTION
it doesn't work properly, especially when faced with dc offsets.

- causes lookahead, followed by lag, in extends levant
- breaks pitch tracking