### PR TITLE
Make trigger/render subsampling preview-only

### DIFF
--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -77,6 +77,8 @@ class Config(
     def before_record(self) -> None:
         """ Called *once* before recording video. Force high-quality rendering. """
         self.render_subfps = 1
+        self.trigger_subsampling = 1
+        self.render_subsampling = 1
         self.render.before_record()
 
     # End Performance

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -198,7 +198,7 @@ class MainWindow(QWidget):
         with self._add_tab(s, tr("&Performance")) as tab:
             set_layout(s, QVBoxLayout)
 
-            with append_widget(s, QGroupBox) as self.perfAll:
+            with append_widget(s, QGroupBox) as self.perfPreview:
                 set_layout(s, QFormLayout)
 
                 with add_row(s, "", BoundSpinBox) as self.trigger_subsampling:
@@ -206,9 +206,6 @@ class MainWindow(QWidget):
 
                 with add_row(s, "", BoundSpinBox) as self.render_subsampling:
                     self.render_subsampling.setMinimum(1)
-
-            with append_widget(s, QGroupBox) as self.perfPreview:
-                set_layout(s, QFormLayout)
 
                 with add_row(s, "", BoundSpinBox) as self.render_subfps:
                     self.render_subfps.setMinimum(1)
@@ -419,10 +416,9 @@ class MainWindow(QWidget):
         self.layout__stereo_orientationL.setText(tr("Stereo Orientation"))
         self.render__stereo_grid_opacityL.setText(tr("Grid Opacity"))
 
-        self.perfAll.setTitle(tr("Preview and Render"))
+        self.perfPreview.setTitle(tr("Preview Only"))
         self.trigger_subsamplingL.setText(tr("Trigger Subsampling"))
         self.render_subsamplingL.setText(tr("Render Subsampling"))
-        self.perfPreview.setTitle(tr("Preview Only"))
         self.render_subfpsL.setText(tr("Render FPS Divisor"))
         self.render__res_divisorL.setText(tr("Resolution Divisor"))
         self.master_audio.setText(tr("/"))


### PR DESCRIPTION
- Defaulting to render subsampling=2 leads to ugly Youtube uploads.
In particular, render subsampling hurts fm and high treble freq bands,
which i did not encounter during earlier testing.
- Render subsampling has marginal performance gain I think.