### PR TITLE
Add Channel.get_render_around()

### DIFF
--- a/corrscope/channel.py
+++ b/corrscope/channel.py
@@ -41,11 +41,11 @@ class ChannelConfig(DumpableAttrs):
 
 class Channel:
     # trigger_samp is unneeded, since __init__ (not CorrScope) constructs triggers.
-    render_samp: int
+    _render_samp: int
 
     # Product of corr_cfg.trigger/render_subsampling and trigger/render_width.
-    trigger_stride: int
-    render_stride: int
+    _trigger_stride: int
+    _render_stride: int
 
     def __init__(self, cfg: ChannelConfig, corr_cfg: "Config"):
         self.cfg = cfg
@@ -78,10 +78,10 @@ class Channel:
             return round(width_s * wave.smp_s / sub)
 
         trigger_samp = calculate_nsamp(corr_cfg.trigger_ms, tsub)
-        self.render_samp = calculate_nsamp(corr_cfg.render_ms, rsub)
+        self._render_samp = calculate_nsamp(corr_cfg.render_ms, rsub)
 
-        self.trigger_stride = tsub * tw
-        self.render_stride = rsub * rw
+        self._trigger_stride = tsub * tw
+        self._render_stride = rsub * rw
 
         # Create a Trigger object.
         if isinstance(cfg.trigger, MainTriggerConfig):
@@ -104,11 +104,11 @@ class Channel:
         self.trigger = tcfg(
             wave=self.trigger_wave,
             tsamp=trigger_samp,
-            stride=self.trigger_stride,
+            stride=self._trigger_stride,
             fps=corr_cfg.fps,
         )
 
     def get_render_around(self, trigger_sample: int):
         return self.render_wave.get_around(
-            trigger_sample, self.render_samp, self.render_stride
+            trigger_sample, self._render_samp, self._render_stride
         )

--- a/corrscope/channel.py
+++ b/corrscope/channel.py
@@ -42,8 +42,6 @@ class ChannelConfig(DumpableAttrs):
 class Channel:
     # trigger_samp is unneeded, since __init__ (not CorrScope) constructs triggers.
     render_samp: int
-    # TODO add a "get_around" method for rendering (also helps test_channel_subsampling)
-    # Currently CorrScope peeks at Channel.render_samp and render_stride (bad).
 
     # Product of corr_cfg.trigger/render_subsampling and trigger/render_width.
     trigger_stride: int
@@ -108,4 +106,9 @@ class Channel:
             tsamp=trigger_samp,
             stride=self.trigger_stride,
             fps=corr_cfg.fps,
+        )
+
+    def get_render_around(self, trigger_sample: int):
+        return self.render_wave.get_around(
+            trigger_sample, self.render_samp, self.render_stride
         )

--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -320,13 +320,7 @@ class CorrScope:
 
                     # Get render data.
                     if should_render:
-                        render_datas.append(
-                            render_wave.get_around(
-                                trigger_sample,
-                                channel.render_samp,
-                                channel.render_stride,
-                            )
-                        )
+                        render_datas.append(channel.get_render_around(trigger_sample))
 
                 if not should_render:
                     continue

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -103,35 +103,35 @@ def test_config_channel_width_stride(
 
     ideal_tsamp = ideal_samp(cfg.trigger_ms, tsub)
     ideal_rsamp = ideal_samp(cfg.render_ms, rsub)
-    assert channel.render_samp == ideal_rsamp
+    assert channel._render_samp == ideal_rsamp
 
-    assert channel.trigger_stride == tsub * c_trigger_width
-    assert channel.render_stride == rsub * c_render_width
+    assert channel._trigger_stride == tsub * c_trigger_width
+    assert channel._render_stride == rsub * c_render_width
 
     # Ensure amplification override works
     args, kwargs = Wave.call_args
     assert kwargs["amplification"] == coalesce(c_amplification, amplification)
 
-    ## Ensure trigger uses channel.window_samp and trigger_stride.
+    ## Ensure trigger uses channel.window_samp and _trigger_stride.
     trigger = channel.trigger
     assert trigger._tsamp == ideal_tsamp
-    assert trigger._stride == channel.trigger_stride
+    assert trigger._stride == channel._trigger_stride
 
-    ## Ensure corrscope calls render using channel.render_samp and render_stride.
+    ## Ensure corrscope calls render using channel._render_samp and _render_stride.
     corr = CorrScope(cfg, Arguments(cfg_dir=".", outputs=[]))
     renderer = mocker.patch.object(CorrScope, "_load_renderer").return_value
     corr.play()
 
     # Only Channel.get_render_around() (not NullTrigger) calls wave.get_around().
     (_sample, _return_nsamp, _subsampling), kwargs = wave.get_around.call_args
-    assert _return_nsamp == channel.render_samp
-    assert _subsampling == channel.render_stride
+    assert _return_nsamp == channel._render_samp
+    assert _subsampling == channel._render_stride
 
     # Inspect arguments to renderer.render_frame()
     # datas: List[np.ndarray]
     (datas,), kwargs = renderer.render_frame.call_args
     render_data = datas[0]
-    assert len(render_data) == channel.render_samp
+    assert len(render_data) == channel._render_samp
 
 
 # line_color is tested in test_renderer.py

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -122,7 +122,7 @@ def test_config_channel_width_stride(
     renderer = mocker.patch.object(CorrScope, "_load_renderer").return_value
     corr.play()
 
-    # Only render (not NullTrigger) calls wave.get_around().
+    # Only Channel.get_render_around() (not NullTrigger) calls wave.get_around().
     (_sample, _return_nsamp, _subsampling), kwargs = wave.get_around.call_args
     assert _return_nsamp == channel.render_samp
     assert _subsampling == channel.render_stride


### PR DESCRIPTION
CorrScope main loop calls Channel.get_render_around(), instead of manually accessing `render_wave` and peeking into Channel fields.

Removed: `render_wave.get_around(trigger_sample, channel.render_samp, channel.render_stride)`