### PR TITLE
Always draw vertical midline between <0 and >0 samples

### DIFF
--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -303,7 +303,8 @@ class MatplotlibRenderer(Renderer):
             for idx, wave_data in enumerate(datas):
                 wave_axes = self._axes2d[idx]
                 for ax in unique_by_id(wave_axes):
-                    max_x = len(wave_data) - 1
+                    N = len(wave_data)
+                    max_x = N - 1
                     ax.set_xlim(0, max_x)
                     ax.set_ylim(-1, 1)
 
@@ -314,7 +315,9 @@ class MatplotlibRenderer(Renderer):
                     # zorder=-100 still draws on top of gridlines :(
                     kw = dict(color=midline_color, linewidth=midline_width)
                     if cfg.v_midline:
-                        ax.axvline(x=max_x / 2, **kw)
+                        # See Wave.get_around() docstring.
+                        # wave_data[N//2] == self[sample], usually > 0.
+                        ax.axvline(x=N // 2 - 0.5, **kw)
                     if cfg.h_midline:
                         ax.axhline(y=0, **kw)
 

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -255,6 +255,7 @@ class CorrelationTrigger(MainTrigger):
     - So wave.get_around(x) = [x - N//2 : ...]
 
     test_trigger() checks that get_around() works properly, for even/odd N.
+    See Wave.get_around() docstring.
     """
 
     cfg: CorrelationTriggerConfig

--- a/corrscope/wave.py
+++ b/corrscope/wave.py
@@ -260,8 +260,9 @@ class Wave:
     def get_around(self, sample: int, return_nsamp: int, stride: int) -> np.ndarray:
         """ Returns `return_nsamp` samples, centered around `sample`,
         sampled with spacing `stride`.
+        result[N//2] == self[sample]. See CorrelationTrigger docstring.
 
-        Copies self.data[...] """
+        Copies self.data[...]. """
         distance = return_nsamp * stride
         begin = sample - distance // 2
         end = begin + distance

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -56,7 +56,10 @@ is_odd = parametrize("is_odd", [False, True])
 def test_trigger(cfg: CorrelationTriggerConfig, is_odd: bool, post_trigger):
     """Ensures that trigger can locate
     the first positive sample of a -+ step exactly,
-    without off-by-1 errors."""
+    without off-by-1 errors.
+
+    See CorrelationTrigger and Wave.get_around() docstrings.
+    """
     wave = Wave("tests/step2400.wav")
     cfg = attr.evolve(cfg, post_trigger=post_trigger)
 


### PR DESCRIPTION
- Add comments on Wave.get_around() even/odd conventions