### PR TITLE
Switch data window to Gaussian

### DIFF
--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -10,7 +10,7 @@ from corrscope.config import KeywordAttrs, CorrError, Alias, with_units
 from corrscope.spectrum import SpectrumConfig, DummySpectrum, LogFreqSpectrum
 from corrscope.util import find, obj_name, iround
 from corrscope.utils.trigger_util import get_period, normalize_buffer, lerp
-from corrscope.utils.windows import leftpad, midpad, rightpad, cosine_flat
+from corrscope.utils.windows import leftpad, midpad, rightpad
 from corrscope.wave import FLOAT
 
 if TYPE_CHECKING:
@@ -416,7 +416,8 @@ class CorrelationTrigger(MainTrigger):
         if semitones:
             diameter, falloff = [round(period * x) for x in cfg.trigger_falloff]
             # 4 periods + left/right falloff.
-            period_symmetric_window = cosine_flat(N, diameter, falloff)
+            data_radius = diameter / 2 + falloff / 2
+            period_symmetric_window = windows.gaussian(N, 0.5 * data_radius)
 
             # Left-sided falloff
             lag_prevention_window = self._lag_prevention_window

--- a/corrscope/utils/windows.py
+++ b/corrscope/utils/windows.py
@@ -43,15 +43,3 @@ def rightpad(data: np.ndarray, n: int, constant_values=1) -> np.ndarray:
     data = np.pad(data, (0, n - len(data)), "constant", constant_values=constant_values)
 
     return data
-
-
-def cosine_flat(n: int, diameter: int, falloff: int) -> np.ndarray:
-    cosine = windows.hann(falloff * 2)
-    # assert cosine.dtype == FLOAT
-    left, right = cosine[:falloff], cosine[falloff:]
-
-    window = np.concatenate([left, np.ones(diameter, dtype=FLOAT), right])
-
-    padded = midpad(window, n)
-    # assert padded.dtype == FLOAT
-    return padded


### PR DESCRIPTION
Seems to reduce jerking and triggering errors.

Switch to cross-correlating Gaussian data to Gaussian buffer. Originally cosine_flat data.

Remove cosine_flat().

- [x] test on other songs
- it's kinda better than before-ish
    - extends levant: Fixes tri jumping.
    - plok beach: improved bass stability (must set mean response to 0.5+)
    - plok boss (unreleased): looks good (unknown before)
        - SpectrumConfig.min_hz = 10
    - sonic gba pulse: better-ish than before
    - time trax: ok (unknown before)
        - synth sweeps barely jump
        - low sines jump constantly
