### PR TITLE
Add support for per-channel labels

### DIFF
--- a/corrscope/channel.py
+++ b/corrscope/channel.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 class ChannelConfig(DumpableAttrs):
     wav_path: str
-    title: str = ""
+    label: str = ""
 
     # Supplying a dict inherits attributes from global trigger.
     # TODO test channel-specific triggers
@@ -49,8 +49,8 @@ class ChannelConfig(DumpableAttrs):
 
 
 @unique
-class DefaultTitle(TypedEnumDump):
-    NoTitle = 0
+class DefaultLabel(TypedEnumDump):
+    NoLabel = 0
     FileName = auto()
     Number = auto()
 
@@ -67,12 +67,12 @@ class Channel:
         """channel_idx counts from 0."""
         self.cfg = cfg
 
-        self.title = cfg.title
-        if not self.title:
-            if corr_cfg.default_title is DefaultTitle.FileName:
-                self.title = Path(cfg.wav_path).stem
-            elif corr_cfg.default_title is DefaultTitle.Number:
-                self.title = str(channel_idx + 1)
+        self.label = cfg.label
+        if not self.label:
+            if corr_cfg.default_label is DefaultLabel.FileName:
+                self.label = Path(cfg.wav_path).stem
+            elif corr_cfg.default_label is DefaultLabel.Number:
+                self.label = str(channel_idx + 1)
 
         # Create a Wave object.
         wave = Wave(

--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -10,7 +10,7 @@ from typing import Optional, List, Callable
 import attr
 
 from corrscope import outputs as outputs_
-from corrscope.channel import Channel, ChannelConfig, DefaultTitle
+from corrscope.channel import Channel, ChannelConfig, DefaultLabel
 from corrscope.config import KeywordAttrs, DumpEnumAsStr, CorrError, with_units
 from corrscope.layout import LayoutConfig
 from corrscope.outputs import FFmpegOutputConfig
@@ -85,7 +85,7 @@ class Config(
 
     # Multiplies by trigger_width, render_width. Can override trigger.
     channels: List[ChannelConfig]
-    default_title: DefaultTitle = DefaultTitle.NoTitle
+    default_label: DefaultLabel = DefaultLabel.NoLabel
 
     layout: LayoutConfig
     render: RendererConfig
@@ -244,7 +244,7 @@ class CorrScope:
         renderer = self._load_renderer()
         self.renderer = renderer  # only used for unit tests
 
-        renderer.add_titles([channel.title for channel in self.channels])
+        renderer.add_labels([channel.label for channel in self.channels])
 
         if PRINT_TIMESTAMP:
             begin = time.perf_counter()

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -733,11 +733,11 @@ class ConfigModel(PresentationModel):
     ]
 
     @safe_property
-    def render__qfont(self) -> QFont:
+    def render__label_qfont(self) -> QFont:
         qfont = QFont()
         qfont.setStyleHint(QFont.SansSerif)  # no-op on X11
 
-        font = self.cfg.render.font
+        font = self.cfg.render.label_font
         if font.toString:
             qfont.fromString(font.toString)
             return qfont
@@ -753,10 +753,10 @@ class ConfigModel(PresentationModel):
         qfont.setPointSizeF(font.size)
         return qfont
 
-    @render__qfont.setter
-    def render__qfont(self, qfont: QFont):
-        self.cfg.render.font = attr.evolve(
-            self.cfg.render.font,
+    @render__label_qfont.setter
+    def render__label_qfont(self, qfont: QFont):
+        self.cfg.render.label_font = attr.evolve(
+            self.cfg.render.label_font,
             # Font file selection
             family=qfont.family(),
             bold=qfont.bold(),

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -26,7 +26,7 @@ from PyQt5.QtGui import QFont, QCloseEvent, QDesktopServices
 import corrscope
 import corrscope.settings.global_prefs as gp
 from corrscope import cli
-from corrscope.channel import ChannelConfig, DefaultTitle
+from corrscope.channel import ChannelConfig, DefaultLabel
 from corrscope.config import CorrError, copy_config, yaml
 from corrscope.corrscope import CorrScope, Config, Arguments, default_config
 from corrscope.gui.history_file_dlg import (
@@ -49,7 +49,7 @@ from corrscope.gui.util import color2hex, Locked, find_ranges, TracebackDialog
 from corrscope.gui.view_mainwindow import MainWindow as Ui_MainWindow
 from corrscope.layout import Orientation, StereoOrientation
 from corrscope.outputs import IOutputConfig, FFplayOutputConfig
-from corrscope.renderer import TitlePosition
+from corrscope.renderer import LabelPosition
 from corrscope.settings import paths
 from corrscope.triggers import (
     CorrelationTriggerConfig,
@@ -719,17 +719,17 @@ class ConfigModel(PresentationModel):
 
     render__line_width = default_property("render__line_width", 1.5)
 
-    combo_symbol_text["default_title"] = [
-        (DefaultTitle.NoTitle, MainWindow.tr("None", "Default Title")),
-        (DefaultTitle.FileName, MainWindow.tr("File Name", "Default Title")),
-        (DefaultTitle.Number, MainWindow.tr("Number", "Default Title")),
+    combo_symbol_text["default_label"] = [
+        (DefaultLabel.NoLabel, MainWindow.tr("None", "Default Label")),
+        (DefaultLabel.FileName, MainWindow.tr("File Name", "Default Label")),
+        (DefaultLabel.Number, MainWindow.tr("Number", "Default Label")),
     ]
 
-    combo_symbol_text["render.title_position"] = [
-        (TitlePosition.LeftTop, "Top Left"),
-        (TitlePosition.LeftBottom, "Bottom Left"),
-        (TitlePosition.RightTop, "Top Right"),
-        (TitlePosition.RightBottom, "Bottom Right"),
+    combo_symbol_text["render.label_position"] = [
+        (LabelPosition.LeftTop, "Top Left"),
+        (LabelPosition.LeftBottom, "Bottom Left"),
+        (LabelPosition.RightTop, "Top Right"),
+        (LabelPosition.RightBottom, "Bottom Right"),
     ]
 
     @safe_property
@@ -845,7 +845,7 @@ class ChannelModel(qc.QAbstractTableModel):
     # columns
     col_data = [
         Column("wav_path", path_strip_quotes, "", "WAV Path"),
-        Column("title", str, "", "Title"),
+        Column("label", str, "", "Label"),
         Column("amplification", float, None, "Amplification\n(override)"),
         Column("line_color", str, None, "Line Color"),
         Column("render_stereo", str, None, "Render Stereo\nDownmix"),

--- a/corrscope/gui/translate.pro
+++ b/corrscope/gui/translate.pro
@@ -1,2 +1,3 @@
 SOURCES += view_mainwindow.py
+SOURCES += __init__.py
 TRANSLATIONS += corrscope_xa.ts

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -169,7 +169,7 @@ class MainWindow(QWidget):
                 ):
                     pass
 
-            with append_widget(s, QGroupBox, title=tr("Titles"), layout=QFormLayout):
+            with append_widget(s, QGroupBox, title=tr("Labels"), layout=QFormLayout):
                 with add_row(s, tr("Font"), BoundFontButton, name="render__qfont"):
                     pass
                 with add_row(
@@ -181,20 +181,20 @@ class MainWindow(QWidget):
                     pass
 
                 with add_row(
-                    s, tr("Title Position"), BoundComboBox, name="render.title_position"
+                    s, tr("Label Position"), BoundComboBox, name="render.label_position"
                 ):
                     pass
                 with add_row(
                     s,
-                    tr("Title Padding"),
+                    tr("Label Padding"),
                     BoundDoubleSpinBox,
-                    name="render.title_padding_ratio",
+                    name="render.label_padding_ratio",
                     maximum=10,
                     singleStep=0.25,
                 ):
                     pass
                 with add_row(
-                    s, tr("Default Title"), BoundComboBox, name="default_title"
+                    s, tr("Default Label"), BoundComboBox, name="default_label"
                 ):
                     pass
 

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -170,13 +170,15 @@ class MainWindow(QWidget):
                     pass
 
             with append_widget(s, QGroupBox, title=tr("Labels"), layout=QFormLayout):
-                with add_row(s, tr("Font"), BoundFontButton, name="render__qfont"):
+                with add_row(
+                    s, tr("Font"), BoundFontButton, name="render__label_qfont"
+                ):
                     pass
                 with add_row(
                     s,
                     tr("Font Color"),
                     OptionalColorWidget,
-                    name="render.font_color_override",
+                    name="render.label_color_override",
                 ):
                     pass
 

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -62,9 +62,9 @@ class MainWindow(QWidget):
 
             # Left-hand config tabs
             with append_widget(s, TabWidget) as self.left_tabs:
-                self.tabGeneral = self.add_general_tab(s)
+                self.add_general_tab(s)
                 self.add_appear_tab(s)
-                self.tabTrigger = self.add_trigger_tab(s)
+                self.add_trigger_tab(s)
 
             # Right-hand channel list
             with append_widget(s, QVBoxLayout) as self.audioColumn:
@@ -141,9 +141,9 @@ class MainWindow(QWidget):
         tr = self.tr
         with self._add_tab(s, tr("&Appearance"), layout=QVBoxLayout) as tab:
 
-            with append_widget(s, QGroupBox) as self.optionAppearance:
-                set_layout(s, QFormLayout)
-
+            with append_widget(
+                s, QGroupBox, title=tr("Appearance"), layout=QFormLayout
+            ):
                 with add_row(s, "", BoundLineEdit) as self.render_resolution:
                     pass
 
@@ -169,9 +169,36 @@ class MainWindow(QWidget):
                 ):
                     pass
 
-            with append_widget(s, QGroupBox) as self.optionLayout:
-                set_layout(s, QFormLayout)
+            with append_widget(s, QGroupBox, title=tr("Titles"), layout=QFormLayout):
+                with add_row(s, tr("Font"), BoundFontButton, name="render__qfont"):
+                    pass
+                with add_row(
+                    s,
+                    tr("Font Color"),
+                    OptionalColorWidget,
+                    name="render.font_color_override",
+                ):
+                    pass
 
+                with add_row(
+                    s, tr("Title Position"), BoundComboBox, name="render.title_position"
+                ):
+                    pass
+                with add_row(
+                    s,
+                    tr("Title Padding"),
+                    BoundDoubleSpinBox,
+                    name="render.title_padding_ratio",
+                    maximum=10,
+                    singleStep=0.25,
+                ):
+                    pass
+                with add_row(
+                    s, tr("Default Title"), BoundComboBox, name="default_title"
+                ):
+                    pass
+
+            with append_widget(s, QGroupBox, title=tr("Layout"), layout=QFormLayout):
                 with add_row(s, "", BoundComboBox) as self.layout__orientation:
                     pass
 
@@ -431,7 +458,6 @@ class MainWindow(QWidget):
         self.render_msL.setText(tr("Render Width"))
         self.amplificationL.setText(tr("Amplification"))
         self.begin_timeL.setText(tr("Begin Time"))
-        self.optionAppearance.setTitle(tr("Appearance"))
         self.render_resolutionL.setText(tr("Resolution"))
         self.render_resolution.setText(tr("vs"))
         self.render__bg_colorL.setText(tr("Background"))
@@ -441,7 +467,6 @@ class MainWindow(QWidget):
         self.render__midline_colorL.setText(tr("Midline Color"))
         self.render__v_midline.setText(tr("Vertical"))
         self.render__h_midline.setText(tr("Horizontal Midline"))
-        self.optionLayout.setTitle(tr("Layout"))
         self.layout__orientationL.setText(tr("Orientation"))
         self.layout__nrowsL.setText(tr("Rows"))
 
@@ -484,6 +509,7 @@ from corrscope.gui.model_bind import (
     TypeComboBox,
     BoundColorWidget,
     OptionalColorWidget,
+    BoundFontButton,
 )
 
 # Delete unbound widgets, so they cannot accidentally be used.

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -126,16 +126,16 @@ class RendererConfig(DumpableAttrs, always_dump="*"):
     h_midline: bool = False
 
     # Label settings
-    font: Font = attr.ib(factory=Font)
+    label_font: Font = attr.ib(factory=Font)
 
     label_position: LabelPosition = LabelPosition.LeftTop
-    # The text will be located (label_padding_ratio * font.size) from the corner.
+    # The text will be located (label_padding_ratio * label_font.size) from the corner.
     label_padding_ratio: float = with_units("px/pt", default=0.5)
-    font_color_override: Optional[str] = None
+    label_color_override: Optional[str] = None
 
     @property
-    def get_font_color(self):
-        return coalesce(self.font_color_override, self.init_line_color)
+    def get_label_color(self):
+        return coalesce(self.label_color_override, self.init_line_color)
 
     antialiasing: bool = True
 
@@ -480,9 +480,9 @@ class MatplotlibRenderer(Renderer):
             )
 
         cfg = self.cfg
-        color = cfg.get_font_color
+        color = cfg.get_label_color
 
-        size_pt = cfg.font.size
+        size_pt = cfg.label_font.size
         distance_px = cfg.label_padding_ratio * size_pt
 
         @attr.dataclass
@@ -519,9 +519,9 @@ class MatplotlibRenderer(Renderer):
                 # Cosmetics
                 color=color,
                 fontsize=size_pt,
-                fontfamily=cfg.font.family,
-                fontweight=("bold" if cfg.font.bold else "normal"),
-                fontstyle=("italic" if cfg.font.italic else "normal"),
+                fontfamily=cfg.label_font.family,
+                fontweight=("bold" if cfg.label_font.bold else "normal"),
+                fontstyle=("italic" if cfg.label_font.italic else "normal"),
             )
             out.append(text)
 

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -1,13 +1,14 @@
+import enum
 import os
 from abc import ABC, abstractmethod
-from typing import Optional, List, TYPE_CHECKING, Any, Callable
+from typing import Optional, List, TYPE_CHECKING, Any, Callable, TypeVar
 
 import attr
 import matplotlib  # do NOT import anything else until we call matplotlib.use().
 import matplotlib.colors
 import numpy as np
 
-from corrscope.config import DumpableAttrs, with_units
+from corrscope.config import DumpableAttrs, with_units, TypedEnumDump
 from corrscope.layout import (
     RendererLayout,
     LayoutConfig,
@@ -30,7 +31,7 @@ and font cache entries point to invalid paths.
 - https://github.com/pyinstaller/pyinstaller/issues/617
 - https://github.com/pyinstaller/pyinstaller/blob/c06d853c0c4df7480d3fa921851354d4ee11de56/PyInstaller/loader/rthooks/pyi_rth_mplconfig.py#L35-L37
 
-corrscope uses one-folder mode, does not use fonts yet,
+corrscope uses one-folder mode
 and deletes all matplotlib-bundled fonts to save space. So reenable global font cache.
 """
 
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
     from matplotlib.artist import Artist
     from matplotlib.axes import Axes
     from matplotlib.lines import Line2D
+    from matplotlib.text import Text, Annotation
     from corrscope.channel import ChannelConfig
 
 
@@ -57,6 +59,55 @@ def default_color() -> str:
     #
     # return matplotlib.colors.to_hex(colors, keep_alpha=False)
     return "#ffffff"
+
+
+T = TypeVar("T")
+
+
+class TitleX(enum.Enum):
+    Left = enum.auto()
+    Right = enum.auto()
+
+    def match(self, *, left: T, right: T) -> T:
+        if self is self.Left:
+            return left
+        if self is self.Right:
+            return right
+        raise ValueError("failed match")
+
+
+class TitleY(enum.Enum):
+    Bottom = enum.auto()
+    Top = enum.auto()
+
+    def match(self, *, bottom: T, top: T) -> T:
+        if self is self.Bottom:
+            return bottom
+        if self is self.Top:
+            return top
+        raise ValueError("failed match")
+
+
+class TitlePosition(TypedEnumDump):
+    def __init__(self, x: TitleX, y: TitleY):
+        self.x = x
+        self.y = y
+
+    LeftBottom = (TitleX.Left, TitleY.Bottom)
+    LeftTop = (TitleX.Left, TitleY.Top)
+    RightBottom = (TitleX.Right, TitleY.Bottom)
+    RightTop = (TitleX.Right, TitleY.Top)
+
+
+class Font(DumpableAttrs, always_dump="*"):
+    # Font file selection
+    family: Optional[str] = None
+    bold: bool = False
+    italic: bool = False
+    # Font size
+    size: float = with_units("pt", default=20)
+    # QFont implementation details
+    toString: str = None
 
 
 class RendererConfig(DumpableAttrs, always_dump="*"):
@@ -73,6 +124,18 @@ class RendererConfig(DumpableAttrs, always_dump="*"):
     midline_color: Optional[str] = None
     v_midline: bool = False
     h_midline: bool = False
+
+    # Title settings
+    font: Font = attr.ib(factory=Font)
+
+    title_position: TitlePosition = TitlePosition.LeftTop
+    # The text will be located (title_padding_ratio * font.size) from the corner.
+    title_padding_ratio: float = with_units("px/pt", default=0.5)
+    font_color_override: Optional[str] = None
+
+    @property
+    def get_font_color(self):
+        return coalesce(self.font_color_override, self.init_line_color)
 
     antialiasing: bool = True
 
@@ -148,6 +211,10 @@ class Renderer(ABC):
 
     @abstractmethod
     def get_frame(self) -> ByteBuffer:
+        ...
+
+    @abstractmethod
+    def add_titles(self, titles: List[str]) -> Any:
         ...
 
 
@@ -399,6 +466,67 @@ class MatplotlibRenderer(Renderer):
             for chan_idx, chan_data in enumerate(wave_data.T):
                 chan_line = wave_lines[chan_idx]
                 chan_line.set_ydata(chan_data)
+
+    # Channel titles
+    def add_titles(self, titles: List[str]) -> List["Text"]:
+        """
+        Updates background, adds text.
+        Do NOT call after calling self.add_lines().
+        """
+        ntitle = len(titles)
+        if ntitle != self.nplots:
+            raise ValueError(
+                f"incorrect titles: {self.nplots} plots but {ntitle} titles"
+            )
+
+        cfg = self.cfg
+        color = cfg.get_font_color
+
+        size_pt = cfg.font.size
+        distance_px = cfg.title_padding_ratio * size_pt
+
+        @attr.dataclass
+        class AxisPosition:
+            pos_axes: float
+            offset_px: float
+            align: str
+
+        xpos = cfg.title_position.x.match(
+            left=AxisPosition(0, distance_px, "left"),
+            right=AxisPosition(1, -distance_px, "right"),
+        )
+        ypos = cfg.title_position.y.match(
+            bottom=AxisPosition(0, distance_px, "bottom"),
+            top=AxisPosition(1, -distance_px, "top"),
+        )
+
+        pos_axes = (xpos.pos_axes, ypos.pos_axes)
+        offset_px = (xpos.offset_px, ypos.offset_px)
+
+        out: List["Text"] = []
+        for title_text, ax in zip(titles, self._axes_mono):
+            # https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.annotate.html
+            # Annotation subclasses Text.
+            text: "Annotation" = ax.annotate(
+                title_text,
+                # Positioning
+                xy=pos_axes,
+                xycoords="axes fraction",
+                xytext=offset_px,
+                textcoords="offset pixels",
+                horizontalalignment=xpos.align,
+                verticalalignment=ypos.align,
+                # Cosmetics
+                color=color,
+                fontsize=size_pt,
+                fontfamily=cfg.font.family,
+                fontweight=("bold" if cfg.font.bold else "normal"),
+                fontstyle=("italic" if cfg.font.italic else "normal"),
+            )
+            out.append(text)
+
+        self._save_background()
+        return out
 
     # Output frames
     def get_frame(self) -> ByteBuffer:

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -176,6 +176,10 @@ class Renderer(ABC):
     ):
         self.cfg = cfg
         self.lcfg = lcfg
+
+        self.w = cfg.width
+        self.h = cfg.height
+
         self.nplots = len(dummy_datas)
 
         assert len(dummy_datas[0].shape) == 2, dummy_datas[0].shape

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -8,7 +8,7 @@ from pytest_mock import MockFixture
 
 import corrscope.channel
 import corrscope.corrscope
-from corrscope.channel import ChannelConfig, Channel, DefaultTitle
+from corrscope.channel import ChannelConfig, Channel, DefaultLabel
 from corrscope.corrscope import default_config, CorrScope, BenchmarkMode, Arguments
 from corrscope.triggers import NullTriggerConfig
 from corrscope.util import coalesce
@@ -19,7 +19,7 @@ positive = hs.integers(min_value=1, max_value=100)
 real = hs.floats(min_value=0, max_value=100)
 maybe_real = hs.one_of(hs.none(), real)
 bools = hs.booleans()
-default_titles = hs.sampled_from(DefaultTitle)
+default_labels = hs.sampled_from(DefaultLabel)
 
 
 @given(
@@ -33,8 +33,8 @@ default_titles = hs.sampled_from(DefaultTitle)
     render_ms=positive,
     tsub=positive,
     rsub=positive,
-    default_title=hs.sampled_from(DefaultTitle),
-    override_title=bools,
+    default_label=hs.sampled_from(DefaultLabel),
+    override_label=bools,
 )
 def test_config_channel_integration(
     # Channel
@@ -47,8 +47,8 @@ def test_config_channel_integration(
     render_ms: int,
     tsub: int,
     rsub: int,
-    default_title: DefaultTitle,
-    override_title: bool,
+    default_label: DefaultLabel,
+    override_label: bool,
     mocker: MockFixture,
 ):
     """ (Tautologically) verify:
@@ -78,7 +78,7 @@ def test_config_channel_integration(
         trigger_width=c_trigger_width,
         render_width=c_render_width,
         amplification=c_amplification,
-        title="title" if override_title else "",
+        label="label" if override_label else "",
     )
 
     def get_cfg():
@@ -89,7 +89,7 @@ def test_config_channel_integration(
             render_subsampling=rsub,
             amplification=amplification,
             channels=[ccfg],
-            default_title=default_title,
+            default_label=default_label,
             trigger=NullTriggerConfig(),
             benchmark_mode=BenchmarkMode.OUTPUT,
         )
@@ -142,18 +142,18 @@ def test_config_channel_integration(
     render_data = datas[0]
     assert len(render_data) == channel._render_samp
 
-    # Inspect arguments to renderer.add_titles().
-    (titles,), kwargs = renderer.add_titles.call_args
-    title = titles[0]
-    if override_title:
-        assert title == "title"
+    # Inspect arguments to renderer.add_labels().
+    (labels,), kwargs = renderer.add_labels.call_args
+    label = labels[0]
+    if override_label:
+        assert label == "label"
     else:
-        if default_title is DefaultTitle.FileName:
-            assert title == "sine440"
-        elif default_title is DefaultTitle.Number:
-            assert title == "1"
+        if default_label is DefaultLabel.FileName:
+            assert label == "sine440"
+        elif default_label is DefaultLabel.Number:
+            assert label == "1"
         else:
-            assert title == ""
+            assert label == ""
 
 
 # line_color is tested in test_renderer.py

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -56,7 +56,7 @@ def test_config_channel_integration(
     - channel.t/r_stride (given cfg.*_subsampling/*_width)
     - trigger._tsamp, _stride
     - renderer's method calls(samp, stride)
-    - rendered title (channel.title, given cfg, corr_cfg.use_filename_as_title)
+    - rendered label (channel.label, given cfg, corr_cfg.default_label)
     """
 
     # region setup test variables

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -168,9 +168,9 @@ def test_label_render(label_position: LabelPosition, data):
         WIDTH,
         HEIGHT,
         antialiasing=False,
-        font=Font(size=16, bold=True),
+        label_font=Font(size=16, bold=True),
         label_position=label_position,
-        font_color_override=font_str,
+        label_color_override=font_str,
     )
 
     lcfg = LayoutConfig()


### PR DESCRIPTION
matplotlib's font weight handling is often wrong.

- [x] tests to ensure Renderer.add_titles() actually does something
- [x] no titles, titles, or numbered titles
- [x] BUG! labels are not shrinked when you decrease resolution scaling
- [x] rename to label_font and label_color_override (consistency)
- [ ] ~~remove "default to line color"?~~

----------

Includes #254, ~~requires #255 to save `renderer._font_color`~~.