### PR TITLE
Replace output/renderer RGB_DEPTH with BYTES_PER_PIXEL

### DIFF
--- a/corrscope/outputs.py
+++ b/corrscope/outputs.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 ByteBuffer = Union[bytes, np.ndarray]
-RGB_DEPTH = 3
+BYTES_PER_PIXEL = 3
 PIXEL_FORMAT = "rgb24"
 
 FRAMES_TO_BUFFER = 2
@@ -44,7 +44,7 @@ class Output(ABC):
 
         rcfg = corr_cfg.render
 
-        frame_bytes = rcfg.height * rcfg.width * RGB_DEPTH
+        frame_bytes = rcfg.height * rcfg.width * BYTES_PER_PIXEL
         self.bufsize = frame_bytes * FRAMES_TO_BUFFER
 
     def __enter__(self):

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -15,7 +15,7 @@ from corrscope.layout import (
     RegionSpec,
     Edges,
 )
-from corrscope.outputs import RGB_DEPTH, ByteBuffer
+from corrscope.outputs import BYTES_PER_PIXEL, ByteBuffer
 from corrscope.util import coalesce
 
 """
@@ -419,7 +419,7 @@ class MatplotlibRenderer(Renderer):
         assert (w, h) == canvas.get_width_height()
 
         buffer_rgb = canvas.tostring_rgb()
-        assert len(buffer_rgb) == w * h * RGB_DEPTH
+        assert len(buffer_rgb) == w * h * BYTES_PER_PIXEL
 
         return buffer_rgb
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -15,7 +15,7 @@ import pytest
 from corrscope.channel import ChannelConfig
 from corrscope.corrscope import default_config, Config, CorrScope, Arguments
 from corrscope.outputs import (
-    RGB_DEPTH,
+    BYTES_PER_PIXEL,
     FFmpegOutput,
     FFmpegOutputConfig,
     FFplayOutput,
@@ -99,7 +99,7 @@ def test_render_output():
 def test_output():
     out: FFmpegOutput = NULL_FFMPEG_OUTPUT(CFG)
 
-    frame = bytes(WIDTH * HEIGHT * RGB_DEPTH)
+    frame = bytes(WIDTH * HEIGHT * BYTES_PER_PIXEL)
     out.write_frame(frame)
 
     assert out.close() == 0

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -7,7 +7,7 @@ import pytest
 from corrscope.channel import ChannelConfig
 from corrscope.corrscope import CorrScope, default_config, Arguments
 from corrscope.layout import LayoutConfig
-from corrscope.outputs import RGB_DEPTH, FFplayOutputConfig
+from corrscope.outputs import BYTES_PER_PIXEL, FFplayOutputConfig
 from corrscope.renderer import RendererConfig, MatplotlibRenderer
 from corrscope.wave import Flatten
 
@@ -100,7 +100,7 @@ def verify(
 ):
     r.update_main_lines(datas)
     frame_colors: np.ndarray = np.frombuffer(r.get_frame(), dtype=np.uint8).reshape(
-        (-1, RGB_DEPTH)
+        (-1, BYTES_PER_PIXEL)
     )
 
     bg_u8 = to_rgb(bg_str)


### PR DESCRIPTION
The new name expresses the semantic meaning of this constant. The old name is tied to RGB 3-byte color depth.