### PR TITLE
Fix label scaling, rewrite resolution divisor

### DIFF
--- a/corrscope/outputs.py
+++ b/corrscope/outputs.py
@@ -44,7 +44,7 @@ class Output(ABC):
 
         rcfg = corr_cfg.render
 
-        frame_bytes = rcfg.height * rcfg.width * BYTES_PER_PIXEL
+        frame_bytes = rcfg.divided_height * rcfg.divided_width * BYTES_PER_PIXEL
         self.bufsize = frame_bytes * FRAMES_TO_BUFFER
 
     def __enter__(self):
@@ -116,8 +116,8 @@ class _FFmpegProcess:
 
 def ffmpeg_input_video(cfg: "Config") -> List[str]:
     fps = cfg.render_fps
-    width = cfg.render.width
-    height = cfg.render.height
+    width = cfg.render.divided_width
+    height = cfg.render.divided_height
 
     return [
         f"-f rawvideo -pixel_format {PIXEL_FORMAT} -video_size {width}x{height}",

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -117,11 +117,11 @@ class RendererConfig(DumpableAttrs, always_dump="*"):
 
     @property
     def divided_width(self):
-        return round(self.width / self.res_divisor)
+        return int(self.width / self.res_divisor)
 
     @property
     def divided_height(self):
-        return round(self.height / self.res_divisor)
+        return int(self.height / self.res_divisor)
 
     bg_color: str = "#000000"
     init_line_color: str = default_color()
@@ -300,6 +300,9 @@ class MatplotlibRenderer(Renderer):
         self._fig.set_dpi(DPI / cfg.res_divisor)
         self._fig.set_size_inches(self.cfg.width / DPI, self.cfg.height / DPI)
         FigureCanvasAgg(self._fig)
+
+        real_dims = self._fig.canvas.get_width_height()
+        assert (self.w, self.h) == real_dims, [(self.w, self.h), real_dims]
 
         # Setup background
         self._fig.set_facecolor(cfg.bg_color)
@@ -551,8 +554,6 @@ class MatplotlibRenderer(Renderer):
             raise RuntimeError(
                 f"oh shit, cannot read data from {type(canvas)} != FigureCanvasAgg"
             )
-
-        assert (self.w, self.h) == canvas.get_width_height()
 
         buffer_rgb = canvas.tostring_rgb()
         assert len(buffer_rgb) == self.w * self.h * BYTES_PER_PIXEL

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -188,7 +188,8 @@ class Renderer(ABC):
 
         self.nplots = len(dummy_datas)
 
-        assert len(dummy_datas[0].shape) == 2, dummy_datas[0].shape
+        if self.nplots > 0:
+            assert len(dummy_datas[0].shape) == 2, dummy_datas[0].shape
         self.wave_nsamps = [data.shape[0] for data in dummy_datas]
         self.wave_nchans = [data.shape[1] for data in dummy_datas]
 

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -230,14 +230,12 @@ class Renderer(ABC):
 
 
 Point = float
-px_inch = 96
-pt_inch = 72
-
-DPI = px_inch
+PX_INCH = 96
+POINT_INCH = 72
 
 
 def pixels(px: float) -> Point:
-    return px / px_inch * pt_inch
+    return px / PX_INCH * POINT_INCH
 
 
 class MatplotlibRenderer(Renderer):
@@ -300,25 +298,27 @@ class MatplotlibRenderer(Renderer):
         self._fig = Figure()
         FigureCanvasAgg(self._fig)
 
-        dpi = DPI / cfg.res_divisor
-        self._fig.set_dpi(dpi)
+        px_inch = PX_INCH / cfg.res_divisor
+        self._fig.set_dpi(px_inch)
 
         """
         Requirements:
-        - dpi /= res_divisor (to scale visual elements correctly)
-        - int(set_size_inches * dpi) == self.w,h
+        - px_inch /= res_divisor (to scale visual elements correctly)
+        - int(set_size_inches * px_inch) == self.w,h
             - matplotlib uses int instead of round. Who knows why.
                 I hope they don't change behavior in a future update.
 
         Solution:
-        - [int(set_size_inches * dpi) == self.w,h] from above
-        - [round(set_size_inches * dpi) == self.w,h]
+        - [int(set_size_inches * px_inch) == self.w,h] from above
+        - [round(set_size_inches * px_inch) == self.w,h]
             just in case matplotlib changes its mind
-        - set_size_inches * dpi == self.w,h + 0.25
-        - set_size_inches == self.w,h + 0.25 ,/ dpi
+        - set_size_inches * px_inch == self.w,h + 0.25
+        - set_size_inches == self.w,h + 0.25 ,/ px_inch
         """
         offset = 0.25
-        self._fig.set_size_inches((self.w + offset) / dpi, (self.h + offset) / dpi)
+        self._fig.set_size_inches(
+            (self.w + offset) / px_inch, (self.h + offset) / px_inch
+        )
 
         real_dims = self._fig.canvas.get_width_height()
         assert (self.w, self.h) == real_dims, [(self.w, self.h), real_dims]

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -297,9 +297,27 @@ class MatplotlibRenderer(Renderer):
         cfg = self.cfg
 
         self._fig = Figure()
-        self._fig.set_dpi(DPI / cfg.res_divisor)
-        self._fig.set_size_inches(self.cfg.width / DPI, self.cfg.height / DPI)
         FigureCanvasAgg(self._fig)
+
+        dpi = DPI / cfg.res_divisor
+        self._fig.set_dpi(dpi)
+
+        """
+        Requirements:
+        - dpi /= res_divisor (to scale visual elements correctly)
+        - int(set_size_inches * dpi) == self.w,h
+            - matplotlib uses int instead of round. Who knows why.
+                I hope they don't change behavior in a future update.
+
+        Solution:
+        - [int(set_size_inches * dpi) == self.w,h] from above
+        - [round(set_size_inches * dpi) == self.w,h]
+            just in case matplotlib changes its mind
+        - set_size_inches * dpi == self.w,h + 0.25
+        - set_size_inches == self.w,h + 0.25 ,/ dpi
+        """
+        offset = 0.25
+        self._fig.set_size_inches((self.w + offset) / dpi, (self.h + offset) / dpi)
 
         real_dims = self._fig.canvas.get_width_height()
         assert (self.w, self.h) == real_dims, [(self.w, self.h), real_dims]

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -117,11 +117,11 @@ class RendererConfig(DumpableAttrs, always_dump="*"):
 
     @property
     def divided_width(self):
-        return int(self.width / self.res_divisor)
+        return round(self.width / self.res_divisor)
 
     @property
     def divided_height(self):
-        return int(self.height / self.res_divisor)
+        return round(self.height / self.res_divisor)
 
     bg_color: str = "#000000"
     init_line_color: str = default_color()

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -115,6 +115,14 @@ class RendererConfig(DumpableAttrs, always_dump="*"):
     height: int
     line_width: float = with_units("px", default=1.5)
 
+    @property
+    def divided_width(self):
+        return round(self.width / self.res_divisor)
+
+    @property
+    def divided_height(self):
+        return round(self.height / self.res_divisor)
+
     bg_color: str = "#000000"
     init_line_color: str = default_color()
 
@@ -148,14 +156,12 @@ class RendererConfig(DumpableAttrs, always_dump="*"):
         assert isinstance(self.height, (int, float))
 
     def before_preview(self) -> None:
-        """ Called *once* before preview. Decreases render resolution/etc. """
-        self.width = round(self.width / self.res_divisor)
-        self.height = round(self.height / self.res_divisor)
-        self.line_width /= self.res_divisor
+        """ Called *once* before preview. Does nothing. """
+        pass
 
     def before_record(self) -> None:
-        """ Called *once* before recording video. Does nothing yet. """
-        pass
+        """ Called *once* before recording video. Eliminates res_divisor. """
+        self.res_divisor = 1
 
 
 @attr.dataclass
@@ -177,8 +183,8 @@ class Renderer(ABC):
         self.cfg = cfg
         self.lcfg = lcfg
 
-        self.w = cfg.width
-        self.h = cfg.height
+        self.w = cfg.divided_width
+        self.h = cfg.divided_height
 
         self.nplots = len(dummy_datas)
 
@@ -291,7 +297,7 @@ class MatplotlibRenderer(Renderer):
         cfg = self.cfg
 
         self._fig = Figure()
-        self._fig.set_dpi(DPI)
+        self._fig.set_dpi(DPI / cfg.res_divisor)
         self._fig.set_size_inches(self.cfg.width / DPI, self.cfg.height / DPI)
         FigureCanvasAgg(self._fig)
 
@@ -505,7 +511,7 @@ class MatplotlibRenderer(Renderer):
         )
 
         pos_axes = (xpos.pos_axes, ypos.pos_axes)
-        offset_px = (xpos.offset_px, ypos.offset_px)
+        offset_pt = (pixels(xpos.offset_px), pixels(ypos.offset_px))
 
         out: List["Text"] = []
         for label_text, ax in zip(labels, self._axes_mono):
@@ -516,8 +522,8 @@ class MatplotlibRenderer(Renderer):
                 # Positioning
                 xy=pos_axes,
                 xycoords="axes fraction",
-                xytext=offset_px,
-                textcoords="offset pixels",
+                xytext=offset_pt,
+                textcoords="offset points",
                 horizontalalignment=xpos.align,
                 verticalalignment=ypos.align,
                 # Cosmetics
@@ -546,12 +552,10 @@ class MatplotlibRenderer(Renderer):
                 f"oh shit, cannot read data from {type(canvas)} != FigureCanvasAgg"
             )
 
-        w = self.cfg.width
-        h = self.cfg.height
-        assert (w, h) == canvas.get_width_height()
+        assert (self.w, self.h) == canvas.get_width_height()
 
         buffer_rgb = canvas.tostring_rgb()
-        assert len(buffer_rgb) == w * h * BYTES_PER_PIXEL
+        assert len(buffer_rgb) == self.w * self.h * BYTES_PER_PIXEL
 
         return buffer_rgb
 

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -306,14 +306,12 @@ class MatplotlibRenderer(Renderer):
         - px_inch /= res_divisor (to scale visual elements correctly)
         - int(set_size_inches * px_inch) == self.w,h
             - matplotlib uses int instead of round. Who knows why.
-                I hope they don't change behavior in a future update.
+        - round(set_size_inches * px_inch) == self.w,h
+            - just in case matplotlib changes its mind
 
         Solution:
-        - [int(set_size_inches * px_inch) == self.w,h] from above
-        - [round(set_size_inches * px_inch) == self.w,h]
-            just in case matplotlib changes its mind
-        - set_size_inches * px_inch == self.w,h + 0.25
-        - set_size_inches == self.w,h + 0.25 ,/ px_inch
+        - (set_size_inches * px_inch) == self.w,h + 0.25
+        - set_size_inches == (self.w,h + 0.25) / px_inch
         """
         offset = 0.25
         self._fig.set_size_inches(

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -349,15 +349,15 @@ def test_preview_performance(Popen, mocker: "pytest_mock.MockFixture", outputs):
     for r in records:
         r.assert_not_called()
 
+    # Check renderer is 128x72
+    assert corr.renderer.w == 128
+    assert corr.renderer.h == 72
+
     # Ensure subfps is enabled (only odd frames are rendered, 1..29).
     # See CorrScope `should_render` variable.
     assert (
         get_frame.call_count == round(cfg.end_time * cfg.fps / cfg.render_subfps) == 15
     )
-
-    # Check renderer is 128x72. (call get_frame() after checking call_count above)
-    frame_bytes = corr.renderer.get_frame()
-    assert len(frame_bytes) == 128 * 72 * BYTES_PER_PIXEL
 
 
 YES_FFMPEG = [l + [FFmpegOutputConfig(None)] for l in NO_FFMPEG]

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -339,6 +339,8 @@ def test_preview_performance(Popen, mocker: "pytest_mock.MockFixture", outputs):
 
     cfg = cfg_192x108()
     corr = CorrScope(cfg, Arguments(".", outputs))
+
+    # Run corrscope main loop.
     corr.play()
 
     # Check that only before_preview() called.
@@ -347,15 +349,15 @@ def test_preview_performance(Popen, mocker: "pytest_mock.MockFixture", outputs):
     for r in records:
         r.assert_not_called()
 
-    # Check renderer is 128x72
-    assert corr.renderer.cfg.width == 128
-    assert corr.renderer.cfg.height == 72
-
     # Ensure subfps is enabled (only odd frames are rendered, 1..29).
     # See CorrScope `should_render` variable.
     assert (
         get_frame.call_count == round(cfg.end_time * cfg.fps / cfg.render_subfps) == 15
     )
+
+    # Check renderer is 128x72. (call get_frame() after checking call_count above)
+    frame_bytes = corr.renderer.get_frame()
+    assert len(frame_bytes) == 128 * 72 * BYTES_PER_PIXEL
 
 
 YES_FFMPEG = [l + [FFmpegOutputConfig(None)] for l in NO_FFMPEG]


### PR DESCRIPTION
apparently int(x/96*96) == x, but when I start introducing unusual DPIs, matplotlib ends up with dimensional mismatches.

This should fix dimension mismatches entirely.