### PR TITLE
Make renderer backends pluggable, store constants inside

### DIFF
--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -14,7 +14,7 @@ from corrscope.channel import Channel, ChannelConfig, DefaultLabel
 from corrscope.config import KeywordAttrs, DumpEnumAsStr, CorrError, with_units
 from corrscope.layout import LayoutConfig
 from corrscope.outputs import FFmpegOutputConfig
-from corrscope.renderer import MatplotlibRenderer, RendererConfig, Renderer
+from corrscope.renderer import Renderer, RendererConfig, BaseRenderer
 from corrscope.triggers import CorrelationTriggerConfig, PerFrameCache, SpectrumConfig
 from corrscope.util import pushd, coalesce
 from corrscope.wave import Wave, Flatten
@@ -217,9 +217,9 @@ class CorrScope:
                 ]
                 yield
 
-    def _load_renderer(self) -> Renderer:
+    def _load_renderer(self) -> BaseRenderer:
         dummy_datas = [channel.get_render_around(0) for channel in self.channels]
-        renderer = MatplotlibRenderer(
+        renderer = Renderer(
             self.cfg.render, self.cfg.layout, dummy_datas, self.cfg.channels
         )
         return renderer

--- a/corrscope/designNotes.md
+++ b/corrscope/designNotes.md
@@ -1,0 +1,14 @@
+# Design Notes
+
+## Renderer to Output
+
+- `renderer.py` produces a frame-buffer format which is passed to `outputs.py`. This is a cross-cutting concern, and the 2 modules must agree on bytes per pixel and pixel format.
+- Each renderer returns a different pixel format, and I switch renderers more often than outputs.
+- `tests/test_renderer.py` must convert hexadecimal colors to the right pixel format, for comparison.
+
+### Solution
+
+- Each `BaseRenderer` subclass exposes classvars `bytes_per_pixel` and `ffmpeg_pixel_format`.
+- `renderer.py` exposes `Renderer = preferred subclass`.
+- `outputs.py` imports `renderer.Renderer` and uses the format stored within.
+- Additionally, `tests/test_renderer.py` uses `Renderer.color_to_bytes()`

--- a/corrscope/outputs.py
+++ b/corrscope/outputs.py
@@ -5,18 +5,13 @@ from abc import ABC, abstractmethod
 from os.path import abspath
 from typing import TYPE_CHECKING, Type, List, Union, Optional, ClassVar, Callable
 
-import numpy as np
-
 from corrscope.config import DumpableAttrs
+from corrscope.renderer import ByteBuffer, Renderer
 from corrscope.settings.paths import MissingFFmpegError
 
 if TYPE_CHECKING:
     from corrscope.corrscope import Config
 
-
-ByteBuffer = Union[bytes, np.ndarray]
-BYTES_PER_PIXEL = 3
-PIXEL_FORMAT = "rgb24"
 
 FRAMES_TO_BUFFER = 2
 
@@ -44,7 +39,9 @@ class Output(ABC):
 
         rcfg = corr_cfg.render
 
-        frame_bytes = rcfg.divided_height * rcfg.divided_width * BYTES_PER_PIXEL
+        frame_bytes = (
+            rcfg.divided_height * rcfg.divided_width * Renderer.bytes_per_pixel
+        )
         self.bufsize = frame_bytes * FRAMES_TO_BUFFER
 
     def __enter__(self):
@@ -120,8 +117,8 @@ def ffmpeg_input_video(cfg: "Config") -> List[str]:
     height = cfg.render.divided_height
 
     return [
-        f"-f rawvideo -pixel_format {PIXEL_FORMAT} -video_size {width}x{height}",
-        f"-framerate {fps}",
+        f"-f rawvideo -pixel_format {Renderer.ffmpeg_pixel_format}",
+        f"-video_size {width}x{height} -framerate {fps}",
         *FFMPEG_QUIET,
         "-i -",
     ]

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -295,11 +295,11 @@ class AbstractMatplotlibRenderer(BaseRenderer, ABC):
     To pick a backend, subclass and set canvas_type at the class level.
     """
 
-    canvas_type: Type["FigureCanvasBase"] = abstract_classvar
+    _canvas_type: Type["FigureCanvasBase"] = abstract_classvar
 
     @staticmethod
     @abstractmethod
-    def canvas_to_bytes(canvas: "FigureCanvasBase") -> ByteBuffer:
+    def _canvas_to_bytes(canvas: "FigureCanvasBase") -> ByteBuffer:
         pass
 
     def __init__(self, *args, **kwargs):
@@ -339,7 +339,7 @@ class AbstractMatplotlibRenderer(BaseRenderer, ABC):
         cfg = self.cfg
 
         self._fig = Figure()
-        self.canvas_type(self._fig)
+        self._canvas_type(self._fig)
 
         px_inch = PX_INCH / cfg.res_divisor
         self._fig.set_dpi(px_inch)
@@ -614,12 +614,12 @@ class AbstractMatplotlibRenderer(BaseRenderer, ABC):
 
         # Agg is the default noninteractive backend except on OSX.
         # https://matplotlib.org/faq/usage_faq.html
-        if not isinstance(canvas, self.canvas_type):
+        if not isinstance(canvas, self._canvas_type):
             raise RuntimeError(
-                f"oh shit, cannot read data from {obj_name(canvas)} != {self.canvas_type.__name__}"
+                f"oh shit, cannot read data from {obj_name(canvas)} != {self._canvas_type.__name__}"
             )
 
-        buffer_rgb = self.canvas_to_bytes(canvas)
+        buffer_rgb = self._canvas_to_bytes(canvas)
         assert len(buffer_rgb) == self.w * self.h * self.bytes_per_pixel
 
         return buffer_rgb
@@ -652,10 +652,10 @@ class AbstractMatplotlibRenderer(BaseRenderer, ABC):
 
 class MatplotlibAggRenderer(AbstractMatplotlibRenderer):
     # implements AbstractMatplotlibRenderer
-    canvas_type = FigureCanvasAgg
+    _canvas_type = FigureCanvasAgg
 
     @staticmethod
-    def canvas_to_bytes(canvas: FigureCanvasAgg) -> ByteBuffer:
+    def _canvas_to_bytes(canvas: FigureCanvasAgg) -> ByteBuffer:
         return canvas.tostring_rgb()
 
     # implements BaseRenderer

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -14,7 +14,7 @@ from corrscope.layout import (
     Orientation,
     StereoOrientation,
 )
-from corrscope.renderer import RendererConfig, MatplotlibRenderer
+from corrscope.renderer import RendererConfig, Renderer
 from corrscope.util import ceildiv
 from tests.test_renderer import WIDTH, HEIGHT, RENDER_Y_ZEROS
 
@@ -222,7 +222,7 @@ def test_renderer_layout():
     nplots = 15
 
     datas = [RENDER_Y_ZEROS] * nplots
-    r = MatplotlibRenderer(cfg, lcfg, datas, None)
+    r = Renderer(cfg, lcfg, datas, None)
     r.update_main_lines(datas)
     layout = r.layout
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -15,20 +15,22 @@ import pytest
 from corrscope.channel import ChannelConfig
 from corrscope.corrscope import default_config, Config, CorrScope, Arguments
 from corrscope.outputs import (
-    BYTES_PER_PIXEL,
     FFmpegOutput,
     FFmpegOutputConfig,
     FFplayOutput,
     FFplayOutputConfig,
     Stop,
 )
-from corrscope.renderer import RendererConfig, MatplotlibRenderer
+from corrscope.renderer import RendererConfig, Renderer
 from tests.test_renderer import RENDER_Y_ZEROS, WIDTH, HEIGHT
 
 
 if TYPE_CHECKING:
     import pytest_mock
     from unittest.mock import MagicMock
+
+
+BYTES_PER_PIXEL = Renderer.bytes_per_pixel
 
 
 # Global setup
@@ -86,7 +88,7 @@ def test_render_output():
     """ Ensure rendering to output does not raise exceptions. """
     datas = [RENDER_Y_ZEROS]
 
-    renderer = MatplotlibRenderer(CFG.render, CFG.layout, datas, channel_cfgs=None)
+    renderer = Renderer(CFG.render, CFG.layout, datas, channel_cfgs=None)
     out: FFmpegOutput = NULL_FFMPEG_OUTPUT(CFG)
 
     renderer.update_main_lines(datas)
@@ -168,7 +170,7 @@ def test_corr_terminate_ffplay(Popen, mocker: "pytest_mock.MockFixture"):
     cfg = sine440_config()
     corr = CorrScope(cfg, Arguments(".", [FFplayOutputConfig()]))
 
-    update_main_lines = mocker.patch.object(MatplotlibRenderer, "update_main_lines")
+    update_main_lines = mocker.patch.object(Renderer, "update_main_lines")
     update_main_lines.side_effect = DummyException()
     with pytest.raises(DummyException):
         corr.play()
@@ -334,7 +336,7 @@ NO_FFMPEG = [[], [FFplayOutputConfig()]]
 def test_preview_performance(Popen, mocker: "pytest_mock.MockFixture", outputs):
     """ Ensure performance optimizations enabled
     if all outputs are FFplay or others. """
-    get_frame = mocker.spy(MatplotlibRenderer, "get_frame")
+    get_frame = mocker.spy(Renderer, "get_frame")
     previews, records = previews_records(mocker)
 
     cfg = cfg_192x108()
@@ -368,7 +370,7 @@ YES_FFMPEG = [l + [FFmpegOutputConfig(None)] for l in NO_FFMPEG]
 def test_record_performance(Popen, mocker: "pytest_mock.MockFixture", outputs):
     """ Ensure performance optimizations disabled
     if any FFmpegOutputConfig is found. """
-    get_frame = mocker.spy(MatplotlibRenderer, "get_frame")
+    get_frame = mocker.spy(Renderer, "get_frame")
     previews, records = previews_records(mocker)
 
     cfg = cfg_192x108()


### PR DESCRIPTION
Not included: optional mplcairo backend.
- mplcairo is slow for complex scenes and many lines, even slower than Agg.