### PR TITLE
Access PresentationModel properties through dots(?)

### DIFF
--- a/corrscope/gui/model_bind.py
+++ b/corrscope/gui/model_bind.py
@@ -80,11 +80,11 @@ class PresentationModel(qc.QObject):
         except AttributeError:
             return rgetattr(self.cfg, item)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value):
         self.edited.emit()
 
         # Custom properties
-        if hasattr(type(self), key):
+        if hasattr(type(self), key.replace(SEPARATOR, "__")):
             setattr(self, key, value)
         elif rhasattr(self.cfg, key):
             rsetattr(self.cfg, key, value)

--- a/corrscope/gui/model_bind.py
+++ b/corrscope/gui/model_bind.py
@@ -52,6 +52,15 @@ class PresentationModel(qc.QObject):
     Qt's built-in model-view framework expects all models to
     take the form of a database-style numbered [row, column] structure,
     whereas my model takes the form of a key-value struct exposed as a form.
+
+    Each GUI BoundWidget generally reads/writes `widget.pmodel[widget.path]`.
+
+    To access cfg.foo.bar, set BoundWidget's path to read/write
+    pmodel["foo.bar"] or pmodel["foo__bar"].
+
+    To create a GUI field not directly mapping to `cfg`,
+    define a property named "foo__baz", then set BoundWidget's path to read/write
+    pmodel["foo.baz"] or pmodel["foo__baz"].
     """
 
     # These fields are specific to each subclass, and assigned there.


### PR DESCRIPTION
Attributes, properties... either way, all paths must be normalized. Otherwise, altering a.b will not update a__b.