### PR TITLE
Improve GUI dialog path defaults

### DIFF
--- a/corrscope/cli.py
+++ b/corrscope/cli.py
@@ -53,30 +53,25 @@ def _get_file_name(cfg_path: Optional[Path], cfg: Config, ext: str) -> str:
 
 
 T = TypeVar("T")
-Return = str
 
 
-def get_file_stem(
-    cfg_path: Optional[Path], cfg: Config, default: T
-) -> Union[Return, T]:
+def get_file_stem(cfg_path: Optional[Path], cfg: Config, default: T) -> Union[str, T]:
     """
     Returns a "name" (no dir or extension) for saving file or video.
     Defaults to `default`.
 
     Used by GUI as well.
     """
-    Inner = Path
-
     if cfg_path:
         # Current file was saved.
-        file_path_or_name = Inner(cfg_path)
+        file_path_or_name = Path(cfg_path)
 
     # Current file was never saved.
     # Master audio and all channels may/not be absolute paths.
     elif cfg.master_audio:
-        file_path_or_name = Inner(cfg.master_audio)
+        file_path_or_name = Path(cfg.master_audio)
     elif len(cfg.channels) > 0:
-        file_path_or_name = Inner(cfg.channels[0].wav_path)
+        file_path_or_name = Path(cfg.channels[0].wav_path)
     else:
         return default
 

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -102,6 +102,31 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
 
     Opening a document:
     - load_cfg_from_path
+
+    ## Dialog Directory/Filename Generation
+
+    Save-dialog dir is persistent state, saved across program runs.
+    Most recent of:
+    - Any open/save dialog (unless separate_render_dir is True).
+        - self.pref.file_dir_ref, .set()
+    - Load YAML from CLI.
+        - load_cfg_from_path(cfg_path) sets `self.pref.file_dir`.
+    - Load .wav files from CLI.
+        - if isinstance(cfg_or_path, Config):
+            - save_dir = self.compute_save_dir(self.cfg)
+            - self.pref.file_dir = save_dir (if not empty)
+
+    Render-dialog dir is persistent state, = most recent render-save dialog.
+    - self.pref.render_dir, .set()
+
+    Save/render-dialog filename (no dir) is computed on demand, NOT persistent state.
+    - (Currently loaded config path, or master audio, or channel 0) + ext.
+    - Otherwise empty string.
+        - self.get_save_filename() calls cli.get_file_stem().
+
+    CLI filename is the same,
+    but defaults to "corrscope.{yaml, mp4}" instead of empty string.
+    - cli._get_file_name() calls cli.get_file_stem().
     """
 
     def __init__(self, cfg_or_path: Union[Config, Path]):

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -341,14 +341,17 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
         """
         :return: False if user cancels save action.
         """
-        cfg_path_default = self.file_stem + cli.YAML_NAME
 
+        # Name and extension (no folder).
+        cfg_filename = self.file_stem + cli.YAML_NAME
+
+        # Folder is obtained from self.pref.file_dir_ref.
         filters = ["YAML files (*.yaml)", "All files (*)"]
         path = get_save_file_path(
             self.pref.file_dir_ref,
             self,
             "Save As",
-            cfg_path_default,
+            cfg_filename,
             filters,
             cli.YAML_NAME,
         )
@@ -377,14 +380,16 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
             qw.QMessageBox.critical(self, "Error", error_msg)
             return
 
-        video_path = self.file_stem + cli.VIDEO_NAME
+        # Name and extension (no folder).
+        video_filename = self.file_stem + cli.VIDEO_NAME
         filters = ["MP4 files (*.mp4)", "All files (*)"]
 
         # Points to either `file_dir` or `render_dir`.
-        ref = self.pref.render_dir_ref
+        # Folder is obtained from `dir_ref`.
+        dir_ref = self.pref.render_dir_ref
 
         path = get_save_file_path(
-            ref, self, "Render to Video", video_path, filters, cli.VIDEO_NAME
+            dir_ref, self, "Render to Video", video_filename, filters, cli.VIDEO_NAME
         )
         if path:
             name = str(path)

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -220,7 +220,7 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
         if not self.prompt_save():
             return
         name = get_open_file_name(
-            self.pref.file_dir_ref, self, "Open config", ["YAML files (*.yaml)"]
+            self, "Open config", self.pref.file_dir_ref, ["YAML files (*.yaml)"]
         )
         if name:
             cfg_path = Path(name)
@@ -304,7 +304,7 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
 
     def on_master_audio_browse(self):
         name = get_open_file_name(
-            self.pref.file_dir_ref, self, "Open master audio file", FILTER_WAV_FILES
+            self, "Open master audio file", self.pref.file_dir_ref, FILTER_WAV_FILES
         )
         if name:
             master_audio = "master_audio"
@@ -320,7 +320,7 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
 
     def on_channel_add(self):
         wavs = get_open_file_list(
-            self.pref.file_dir_ref, self, "Add audio channels", FILTER_WAV_FILES
+            self, "Add audio channels", self.pref.file_dir_ref, FILTER_WAV_FILES
         )
         if wavs:
             self.channel_view.append_channels(wavs)
@@ -351,9 +351,9 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
         # Folder is obtained from self.pref.file_dir_ref.
         filters = ["YAML files (*.yaml)", "All files (*)"]
         path = get_save_file_path(
-            self.pref.file_dir_ref,
             self,
             "Save As",
+            self.pref.file_dir_ref,
             cfg_filename,
             filters,
             cli.YAML_NAME,
@@ -392,7 +392,7 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
         dir_ref = self.pref.render_dir_ref
 
         path = get_save_file_path(
-            dir_ref, self, "Render to Video", video_filename, filters, cli.VIDEO_NAME
+            self, "Render to Video", dir_ref, video_filename, filters, cli.VIDEO_NAME
         )
         if path:
             name = str(path)

--- a/corrscope/gui/history_file_dlg.py
+++ b/corrscope/gui/history_file_dlg.py
@@ -20,9 +20,9 @@ class FileName:
 
 def _get_hist_name(
     func: Callable[..., Tuple[str, str]],
-    history_dir: _gp.Ref[_gp.GlobalPrefs],
     parent: qw.QWidget,
     title: str,
+    history_dir: _gp.Ref[_gp.GlobalPrefs],
     default_name: Optional[str],
     filters: List[str],
 ) -> Optional[FileName]:
@@ -59,13 +59,13 @@ def _get_hist_name(
 
 
 def get_open_file_name(
-    history_dir: _gp.Ref[_gp.GlobalPrefs],
     parent: qw.QWidget,
     title: str,
+    history_dir: _gp.Ref[_gp.GlobalPrefs],
     filters: List[str],
 ) -> Optional[str]:
     name = _get_hist_name(
-        qw.QFileDialog.getOpenFileName, history_dir, parent, title, None, filters
+        qw.QFileDialog.getOpenFileName, parent, title, history_dir, None, filters
     )
     if name:
         assert name.file_name is not None
@@ -74,13 +74,13 @@ def get_open_file_name(
 
 
 def get_open_file_list(
-    history_dir: _gp.Ref[_gp.GlobalPrefs],
     parent: qw.QWidget,
     title: str,
+    history_dir: _gp.Ref[_gp.GlobalPrefs],
     filters: List[str],
 ) -> Optional[List[str]]:
     name = _get_hist_name(
-        qw.QFileDialog.getOpenFileNames, history_dir, parent, title, None, filters
+        qw.QFileDialog.getOpenFileNames, parent, title, history_dir, None, filters
     )
     if name:
         assert name.file_list is not None
@@ -90,18 +90,18 @@ def get_open_file_list(
 
 # Returns Path for legacy reasons. Others return str.
 def get_save_file_path(
-    history_dir: _gp.Ref[_gp.GlobalPrefs],
     parent: qw.QWidget,
     title: str,
+    history_dir: _gp.Ref[_gp.GlobalPrefs],
     default_name: str,
     filters: List[str],
     default_suffix: str,
 ) -> Optional[Path]:
     name = _get_hist_name(
         qw.QFileDialog.getSaveFileName,
-        history_dir,
         parent,
         title,
+        history_dir,
         default_name,
         filters,
     )

--- a/corrscope/gui/history_file_dlg.py
+++ b/corrscope/gui/history_file_dlg.py
@@ -26,8 +26,11 @@ def _get_hist_name(
     default_name: Optional[str],
     filters: List[str],
 ) -> Optional[FileName]:
-    """Get file name, defaulting to history folder. If user accepts, update history."""
-
+    """
+    Get file name.
+    Default folder is history folder, and `default_name`.folder is discarded.
+    If user accepts, update history.
+    """
     # Get recently used dir.
     dir_or_file: str = history_dir.get()
     if default_name:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,7 +142,7 @@ def test_load_yaml_another_dir(mocker, Popen):
 
     # Issue: this test does not use cli.main() to compute output path.
     # Possible solution: Call cli.main() via Click runner.
-    output = FFmpegOutputConfig(cli.get_path(cfg.master_audio, cli.VIDEO_NAME))
+    output = FFmpegOutputConfig(cli._get_file_name(None, cfg, cli.VIDEO_NAME))
     corr = CorrScope(cfg, Arguments(subdir, [output]))
     corr.play()
 


### PR DESCRIPTION
Save-dialog dir is persistent state, saved across program runs.
Most recent of:
- Any open/save dialog (unless separate_render_dir is True).
    - self.pref.file_dir_ref, .set()
- Load YAML from CLI.
    - load_cfg_from_path(cfg_path) sets `self.pref.file_dir`.
- Load .wav files from CLI.
    - if isinstance(cfg_or_path, Config):
        - save_dir = self.compute_save_dir(self.cfg)
        - self.pref.file_dir = save_dir (if not empty)

Render-dialog dir is persistent state, = most recent render-save dialog.
- self.pref.render_dir, .set()

Save/render-dialog filename (no dir) is computed on demand, NOT persistent state.
- (Currently loaded config path, or master audio, or channel 0) + ext.
- Otherwise empty string.
    - self.get_save_filename() calls cli.get_file_stem().

CLI filename is the same,
but defaults to "corrscope.{yaml, mp4}" instead of empty string.
- cli._get_file_name() calls cli.get_file_stem().