### PR TITLE
Always enable midline color, never None

### DIFF
--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -122,12 +122,7 @@ def default_config(**kwargs) -> Config:
         channels=[],
         layout=LayoutConfig(orientation="v", ncols=1),
         render=RendererConfig(
-            1280,
-            720,
-            res_divisor=4 / 3,
-            midline_color="#404040",
-            v_midline=True,
-            h_midline=True,
+            1280, 720, res_divisor=4 / 3, v_midline=True, h_midline=True
         ),
     )
     return attr.evolve(cfg, **kwargs)

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -173,7 +173,7 @@ class MainWindow(QWidget):
                 with add_row(s, "", OptionalColorWidget) as self.render__grid_color:
                     pass
 
-                with add_row(s, "", OptionalColorWidget) as self.render__midline_color:
+                with add_row(s, "", BoundColorWidget) as self.render__midline_color:
                     pass
 
                 with add_row(s, BoundCheckBox, BoundCheckBox) as (

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -154,7 +154,7 @@ class RendererConfig(
     grid_color: Optional[str] = None
     stereo_grid_opacity: float = 0.5
 
-    midline_color: Optional[str] = None
+    midline_color: Optional[str] = "#404040"
     v_midline: bool = False
     h_midline: bool = False
 

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -154,7 +154,7 @@ class RendererConfig(
     grid_color: Optional[str] = None
     stereo_grid_opacity: float = 0.5
 
-    midline_color: Optional[str] = "#404040"
+    midline_color: str = "#404040"
     v_midline: bool = False
     h_midline: bool = False
 
@@ -541,12 +541,11 @@ class AbstractMatplotlibRenderer(RendererFrontend, ABC):
                 midline_width = cfg.grid_line_width
 
                 # Not quite sure if midlines or gridlines draw on top
-                if midline_color:
-                    kw = dict(color=midline_color, linewidth=midline_width)
-                    if cfg.v_midline:
-                        ax.axvline(x=calc_center(viewport_stride), **kw)
-                    if cfg.h_midline:
-                        ax.axhline(y=0, **kw)
+                kw = dict(color=midline_color, linewidth=midline_width)
+                if cfg.v_midline:
+                    ax.axvline(x=calc_center(viewport_stride), **kw)
+                if cfg.h_midline:
+                    ax.axhline(y=0, **kw)
 
         self._save_background()
 

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -541,11 +541,12 @@ class AbstractMatplotlibRenderer(RendererFrontend, ABC):
                 midline_width = cfg.grid_line_width
 
                 # Not quite sure if midlines or gridlines draw on top
-                kw = dict(color=midline_color, linewidth=midline_width)
-                if cfg.v_midline:
-                    ax.axvline(x=calc_center(viewport_stride), **kw)
-                if cfg.h_midline:
-                    ax.axhline(y=0, **kw)
+                if midline_color:
+                    kw = dict(color=midline_color, linewidth=midline_width)
+                    if cfg.v_midline:
+                        ax.axvline(x=calc_center(viewport_stride), **kw)
+                    if cfg.h_midline:
+                        ax.axhline(y=0, **kw)
 
         self._save_background()
 


### PR DESCRIPTION
Previously, midline was None by default but #404040 in the template. Now it's #404040 by default.

Eliminates bug where unchecking "midline color" switches to blue, instead of transparent.

- [x] make sure it's always dumped (`always_dump="*"`)
- [ ] The midline color text box is wider than the above one, since it has no checkbox taking up width.
![screenshot](https://cdn.discordapp.com/attachments/513639030194307073/584600852153499663/image.png)