### PR TITLE
Flatten Renderer class hierarchy

### DIFF
--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -215,7 +215,16 @@ UpdateOneLine = Callable[[np.ndarray], Any]
 @attr.dataclass
 class CustomLine:
     stride: int
-    xdata: np.ndarray
+    _xdata: np.ndarray = attr.ib(converter=np.array)
+
+    @property
+    def xdata(self) -> np.ndarray:
+        return self._xdata
+
+    @xdata.setter
+    def xdata(self, value):
+        self._xdata = np.array(value)
+
     set_xdata: UpdateOneLine
     set_ydata: UpdateOneLine
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -20,6 +20,7 @@ from corrscope.renderer import (
     calc_center,
     AbstractMatplotlibRenderer,
     RendererFrontend,
+    CustomLine,
 )
 from corrscope.util import perr
 from corrscope.wave import Flatten
@@ -508,3 +509,19 @@ def test_frontend_overrides_backend(mocker: "pytest_mock.MockFixture"):
 
     assert frontend_get_frame.call_count == 1
     assert backend_get_frame.call_count == 1
+
+
+def test_custom_line():
+    def verify(line: CustomLine, xdata: list):
+        line_xdata = line.xdata
+        assert isinstance(line_xdata, np.ndarray)
+        assert line_xdata.tolist() == xdata
+
+    stride = 1
+    noop = lambda x: None
+
+    line = CustomLine(stride, [3], noop, noop)
+    verify(line, [3])
+
+    line.xdata = [4, 4]
+    verify(line, [4, 4])

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -18,6 +18,8 @@ from corrscope.renderer import (
     calc_limits,
     calc_xs,
     calc_center,
+    AbstractMatplotlibRenderer,
+    RendererFrontend,
 )
 from corrscope.util import perr
 from corrscope.wave import Flatten
@@ -412,7 +414,7 @@ def verify_res_divisor_rounding(
     cfg.before_preview()
 
     if speed_hack:
-        mocker.patch.object(Renderer, "_save_background")
+        mocker.patch.object(AbstractMatplotlibRenderer, "_save_background")
         datas = []
     else:
         datas = [RENDER_Y_ZEROS]
@@ -478,3 +480,31 @@ def test_renderer_knows_stride(mocker: "pytest_mock.MockFixture", integration: b
             corr_cfg.render, corr_cfg.layout, [data], [chan_cfg], [channel]
         )
         assert renderer.render_strides == [subsampling * width_mul]
+
+
+# Multiple inheritance tests
+def test_frontend_overrides_backend(mocker: "pytest_mock.MockFixture"):
+    """
+    class Renderer inherits from (RendererFrontend, backend).
+
+    RendererFrontend.get_frame() is a wrapper around backend.get_frame()
+    and should override it (RendererFrontend should come first in MRO).
+
+    Make sure RendererFrontend methods overshadow backend methods.
+    """
+
+    # If RendererFrontend.get_frame() override is removed, delete this entire test.
+    frontend_get_frame = mocker.spy(RendererFrontend, "get_frame")
+    backend_get_frame = mocker.spy(AbstractMatplotlibRenderer, "get_frame")
+
+    corr_cfg = default_config()
+    chan_cfg = ChannelConfig("tests/sine440.wav")
+    channel = Channel(chan_cfg, corr_cfg, channel_idx=0)
+    data = channel.get_render_around(0)
+
+    renderer = Renderer(corr_cfg.render, corr_cfg.layout, [data], [chan_cfg], [channel])
+    renderer.update_main_lines([data])
+    renderer.get_frame()
+
+    assert frontend_get_frame.call_count == 1
+    assert backend_get_frame.call_count == 1


### PR DESCRIPTION
 Backend implementations should not inherit from RendererFrontend, since they don't need to know.

Implementation: Multiple inheritance:
Renderer inherits from (RendererFrontend, backend implementation).
Backend implementation does not know about RendererFrontend.