### PR TITLE
Fix bug where matplotlib would crash on unrecognized fonts

### DIFF
--- a/corrscope.spec
+++ b/corrscope.spec
@@ -49,8 +49,10 @@ a = Analysis(
 # Some dirs are included by PyInstaller hooks and must be removed after the fact.
 _path_excludes = (
     # Matplotlib
+    # Deleting mpl-data/fonts and rendering with an unrecognized font causes matplotlib
+    # to enter an infinite recursive loop of findfont(...DejaVu Sans) and crash.
+    # So don't delete the default fonts.
     """
-    mpl-data/fonts
     mpl-data/images
     mpl-data/sample_data
     """


### PR DESCRIPTION
Increases uncompressed size by ~8MB and compressed size by 2.5MB.